### PR TITLE
Initialize packet data used in tests to avoid warning in ubuntu builds

### DIFF
--- a/reliable.c
+++ b/reliable.c
@@ -2396,19 +2396,19 @@ void test_sequence_buffer_rollover()
     context.sender = reliable_endpoint_create( &sender_config, time );
     context.receiver = reliable_endpoint_create( &receiver_config, time );
 
+    uint8_t packet_data[TEST_MAX_PACKET_BYTES] = { 0 };
+
     int num_packets_sent = 0;
     int i;
     for (i = 0; i <= 32767; ++i)
     {
-        uint8_t packet_data[16];
-        int packet_bytes = sizeof( packet_data ) / sizeof( uint8_t );
+        int packet_bytes = 16 / sizeof( uint8_t );
         reliable_endpoint_next_packet_sequence( context.sender );
         reliable_endpoint_send_packet( context.sender, packet_data, packet_bytes );
 
         ++num_packets_sent;
     }
 
-    uint8_t packet_data[TEST_MAX_PACKET_BYTES];
     int packet_bytes = sizeof( packet_data ) / sizeof( uint8_t );
     reliable_endpoint_next_packet_sequence( context.sender );
     reliable_endpoint_send_packet( context.sender, packet_data, packet_bytes );

--- a/reliable.c
+++ b/reliable.c
@@ -2396,7 +2396,7 @@ void test_sequence_buffer_rollover()
     context.sender = reliable_endpoint_create( &sender_config, time );
     context.receiver = reliable_endpoint_create( &receiver_config, time );
 
-    uint8_t packet_data[TEST_MAX_PACKET_BYTES] = { 0 };
+    uint8_t packet_data[TEST_MAX_PACKET_BYTES] = {};
 
     int num_packets_sent = 0;
     int i;


### PR DESCRIPTION
Said warning is preventing Yojimbo builds to pass CI. E.g.:

https://github.com/mas-bandwidth/yojimbo/actions/runs/20790379551/job/59717783919#step:6:61

==== Building reliable (release) ====
Creating obj/Release/reliable
reliable.c
In file included from /usr/include/string.h:548,
                 from reliable/reliable.h:30,
                 from reliable/reliable.c:25:
In function ‘memcpy’,
    inlined from ‘reliable_endpoint_send_packet’ at reliable/reliable.c:794:9,
    inlined from ‘test_sequence_buffer_rollover’ at reliable/reliable.c:2406:9:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:29:10: error: ‘packet_data’ may be used uninitialized [-Werror=maybe-uninitialized]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
reliable/reliable.c: In function ‘test_sequence_buffer_rollover’:
reliable/reliable.c:2403:17: note: ‘packet_data’ declared here
 2403 |         uint8_t packet_data[16];
      |                 ^~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [reliable.make:129: obj/Release/reliable/reliable.o] Error 1