### PR TITLE
Prepare CMake build for vcpkg packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,16 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(reliable VERSION 1.3.3 LANGUAGES C CXX)
+project(reliable VERSION 1.3.4 LANGUAGES C CXX)
+
+# is this the top level project, or pulled in via add_subdirectory / FetchContent?
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(RELIABLE_TOP_LEVEL TRUE)
+else()
+    set(RELIABLE_TOP_LEVEL FALSE)
+endif()
 
 option(RELIABLE_SANITIZE "Build with AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
+option(RELIABLE_BUILD_TESTS "Build reliable tests, examples and harnesses" ${RELIABLE_TOP_LEVEL})
 
 # default to debug, same as the old premake makefiles
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
@@ -10,7 +18,12 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release)
 endif()
 
-set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+# static MSVC runtime by default, matching the old premake configuration. package
+# managers (e.g. vcpkg) pass their own CMAKE_MSVC_RUNTIME_LIBRARY to match the
+# CRT linkage their consumers expect.
+if(NOT DEFINED CMAKE_MSVC_RUNTIME_LIBRARY)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
@@ -50,37 +63,41 @@ set_target_properties(reliable PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
     WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
-# "test" is a reserved target name in cmake, so the target is reliable_test
-# but the binary is still bin/test. it compiles reliable.c itself with the
-# embedded test suite enabled
+if(RELIABLE_BUILD_TESTS)
 
-add_executable(reliable_test test.cpp reliable.c)
-set_target_properties(reliable_test PROPERTIES OUTPUT_NAME test)
-target_include_directories(reliable_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_compile_definitions(reliable_test PRIVATE
-    RELIABLE_ENABLE_TESTS=1
-    $<$<CONFIG:Debug>:RELIABLE_DEBUG>
-    $<$<CONFIG:Release>:RELIABLE_RELEASE>
-)
+    # "test" is a reserved target name in cmake, so the target is reliable_test
+    # but the binary is still bin/test. it compiles reliable.c itself with the
+    # embedded test suite enabled
 
-foreach(program example soak stats fuzz)
-    add_executable(${program} ${program}.c)
-    target_link_libraries(${program} PRIVATE reliable)
-endforeach()
+    add_executable(reliable_test test.cpp reliable.c)
+    set_target_properties(reliable_test PROPERTIES OUTPUT_NAME test)
+    target_include_directories(reliable_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+    target_compile_definitions(reliable_test PRIVATE
+        RELIABLE_ENABLE_TESTS=1
+        $<$<CONFIG:Debug>:RELIABLE_DEBUG>
+        $<$<CONFIG:Release>:RELIABLE_RELEASE>
+    )
 
-# the libFuzzer harness, built with a standalone driver so it stays healthy in CI.
-# OSS-Fuzz builds the real libFuzzer binary from fuzz_target.c via oss-fuzz/build.sh
+    foreach(program example soak stats fuzz)
+        add_executable(${program} ${program}.c)
+        target_link_libraries(${program} PRIVATE reliable)
+    endforeach()
 
-add_executable(fuzz_target_standalone fuzz_target.c)
-target_compile_definitions(fuzz_target_standalone PRIVATE RELIABLE_FUZZ_STANDALONE)
-target_link_libraries(fuzz_target_standalone PRIVATE reliable)
+    # the libFuzzer harness, built with a standalone driver so it stays healthy in CI.
+    # OSS-Fuzz builds the real libFuzzer binary from fuzz_target.c via oss-fuzz/build.sh
 
-enable_testing()
+    add_executable(fuzz_target_standalone fuzz_target.c)
+    target_compile_definitions(fuzz_target_standalone PRIVATE RELIABLE_FUZZ_STANDALONE)
+    target_link_libraries(fuzz_target_standalone PRIVATE reliable)
 
-add_test(NAME test COMMAND reliable_test)
-add_test(NAME fuzz COMMAND fuzz 20000 12345)
-add_test(NAME soak COMMAND soak 8192 --quiet)
-add_test(NAME fuzz_target COMMAND fuzz_target_standalone 500 12345)
+    enable_testing()
+
+    add_test(NAME test COMMAND reliable_test)
+    add_test(NAME fuzz COMMAND fuzz 20000 12345)
+    add_test(NAME soak COMMAND soak 8192 --quiet)
+    add_test(NAME fuzz_target COMMAND fuzz_target_standalone 500 12345)
+
+endif()
 
 # install rules (used by package managers, e.g. the homebrew formula)
 

--- a/reliable.h
+++ b/reliable.h
@@ -25,10 +25,10 @@
 #ifndef RELIABLE_H
 #define RELIABLE_H
 
-#define RELIABLE_VERSION_FULL    "1.3.3"
+#define RELIABLE_VERSION_FULL    "1.3.4"
 #define RELIABLE_VERSION_MAJOR   1
 #define RELIABLE_VERSION_MINOR   3
-#define RELIABLE_VERSION_PATCH   3
+#define RELIABLE_VERSION_PATCH   4
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Prepares reliable for a port in the microsoft/vcpkg registry, and bumps the version for the next release (v1.3.4).

- Only default `CMAKE_MSVC_RUNTIME_LIBRARY` to the static CRT when the integrator hasn't set it. vcpkg validates that installed libraries match the triplet's CRT linkage (dynamic on `x64-windows`), so the hardcoded static runtime would fail its post-build checks. Regular builds are unchanged — the static-CRT default still applies whenever nothing else sets it.
- Add `RELIABLE_BUILD_TESTS` (defaults ON at top level, following the serialize pattern) so package builds can skip the test/example/soak/stats/fuzz executables that never get installed.
- Bump version macros and project version to 1.3.4. The release check workflow from #41 verifies the bump.

Verified locally: builds and passes tests with the option ON, builds the library alone with it OFF, and the vcpkg overlay port for reliable builds against this branch and passes vcpkg post-build validation on arm64-osx.

🤖 Generated with [Claude Code](https://claude.com/claude-code)