### PR TITLE
Wire-format standard, conformance checker, dead code removal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,19 @@ jobs:
       # fresh seed every run (printed to the log, so failures are reproducible)
       - name: Fuzz (2M iterations)
         run: ./build/bin/fuzz 2000000
+
+  conformance:
+    name: STANDARD.md conformance
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      # Checks the wire-format specification against the implementation. The
+      # checker parses artifacts the real library produces using ONLY what
+      # STANDARD.md states, with no reference to the source. A failure means
+      # the document and the code disagree — decide which is wrong, and fix
+      # that one. A specification nothing verifies drifts, and a drifted spec
+      # is worse than none because independent implementations are built on it.
+      - name: Verify STANDARD.md
+        run: python3 tools/conformance/verify_standard.py
+

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,28 @@
+# .mailmap — canonical identities for git log, shortlog and blame.
+#
+# Git treats every distinct name/email pair as a different person. Without this
+# file, an ownership or contribution analysis silently miscounts: Glenn commits
+# under five identities across these repositories, and attributing four of them
+# to strangers inflates the apparent third-party share of the codebase by
+# thousands of lines. That is not hypothetical — it happened, on 2026-07-21,
+# during a copyright-ownership review, and was caught only by resolving authors
+# by email instead of by name.
+#
+# Contributors: if your entry here is wrong, or you would rather be credited
+# under a different name, send a patch. This file exists to credit people
+# accurately, not to overrule how they wish to be named.
+#
+# Format:  Canonical Name <canonical@email>  Commit Name <commit@email>
+
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn@networknext.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> gafferongames <glenn.fiedler@gmail.com>
+Glenn Fiedler <glenn@mas-bandwidth.com> Glenn Fiedler <Glenn Fiedler>
+
+Jérôme Leclercq <lynix680@gmail.com> Lynix <lynix680@gmail.com>
+Val Vanderschaegen <valere.vanderschaegen@gmail.com> Val V <valere.vanderschaegen@gmail.com>
+NX <nxrighthere@gmail.com> nxrighthere <nxrighthere@gmail.com>
+Vavius <vavius@gmail.com> vavius <vavius@gmail.com>
+Kien Hoang <kienhg96@gmail.com> Hoang Kien <kienhg96@gmail.com>
+Ryan Scott <ryan@ryan-scott.me> Ryan <ryan@ryan-scott.me>

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -32,8 +32,11 @@ difference is computed as `sequence - ack`, and if negative, `65536` is added.
 
 ## Packet Header
 
-The header is **variable length**, between 3 and 9 bytes. Its size depends on
-how much of the acknowledgement state can be elided. It carries three values:
+The header is **variable length, 4 to 9 bytes** — never fewer than 4, because
+the prefix byte, the 16-bit sequence and at least a one-byte ack are always
+present. The upper bound of 9 is the library's
+`RELIABLE_MAX_PACKET_HEADER_BYTES`. Its size within that range depends on how
+much of the acknowledgement state can be elided. It carries three values:
 
 * `sequence` — the sequence number of this packet
 * `ack` — the most recent sequence number received from the far end
@@ -94,6 +97,9 @@ A packet larger than the configured `fragment_above` threshold is split into
 fragments of `fragment_size` bytes each, up to `max_fragments` (256 maximum).
 
 ### Fragment header
+
+Always exactly 5 bytes (`RELIABLE_FRAGMENT_HEADER_BYTES`), followed on
+fragment 0 by the embedded packet header:
 
     [prefix byte]       (uint8)     always exactly 1
     [sequence]          (uint16)    the sequence of the whole packet

--- a/STANDARD.md
+++ b/STANDARD.md
@@ -1,0 +1,159 @@
+# reliable 1.0
+
+This document specifies the **wire format** produced and consumed by the
+reliable library, precisely enough to write an independent implementation that
+interoperates byte-for-byte.
+
+reliable adds packet acknowledgement and fragmentation on top of an unreliable
+datagram transport. It does **not** retransmit. It tells you which packets
+arrived; what you do about the ones that did not is your business.
+
+## Architecture
+
+Every packet carries a **header** describing which packets the sender has
+recently received. Packets larger than a configured threshold are split into
+**fragments**, each with its own small header, and reassembled by the receiver.
+
+There are exactly two packet shapes on the wire, distinguished by bit 0 of the
+first byte:
+
+| bit 0 of byte 0 | shape |
+|---|---|
+| `0` | a regular packet: packet header, then payload |
+| `1` | a fragment: fragment header, then fragment data |
+
+## General Conventions
+
+All multi-byte integers are **little-endian**: `uint16` is written low byte
+first, `uint32` low byte first.
+
+Sequence numbers are 16-bit and **wrap**. All comparisons are modulo 65536; a
+difference is computed as `sequence - ack`, and if negative, `65536` is added.
+
+## Packet Header
+
+The header is **variable length**, between 3 and 9 bytes. Its size depends on
+how much of the acknowledgement state can be elided. It carries three values:
+
+* `sequence` — the sequence number of this packet
+* `ack` — the most recent sequence number received from the far end
+* `ack_bits` — a 32-bit mask of the 32 packets before `ack`, where bit `n` set
+  means `ack - n - 1` was received
+
+### The prefix byte
+
+    bit 0       always 0 for a regular packet (1 means fragment)
+    bit 1       set if byte 0 of ack_bits is NOT 0xFF
+    bit 2       set if byte 1 of ack_bits is NOT 0xFF
+    bit 3       set if byte 2 of ack_bits is NOT 0xFF
+    bit 4       set if byte 3 of ack_bits is NOT 0xFF
+    bit 5       set if (sequence - ack) mod 65536 <= 255
+    bits 6-7    unused, zero
+
+The elision is the whole point. In steady state with no loss, every bit of
+`ack_bits` is set, so all four bytes are `0xFF`, all four flags are clear, and
+none of them are transmitted. A healthy connection carries a 4-byte header; a
+lossy one grows toward 9.
+
+Note the flag polarity: **a set flag means the byte is present**. A clear flag
+means the byte is absent and the decoder must substitute `0xFF`.
+
+### Layout
+
+    [prefix byte]                       (uint8)
+    [sequence]                          (uint16)
+    [ack]                               (uint8 if prefix bit 5, else uint16)
+    [ack_bits byte 0]                   (uint8, only if prefix bit 1)
+    [ack_bits byte 1]                   (uint8, only if prefix bit 2)
+    [ack_bits byte 2]                   (uint8, only if prefix bit 3)
+    [ack_bits byte 3]                   (uint8, only if prefix bit 4)
+
+When prefix bit 5 is set, the `ack` field is not the sequence number itself but
+the **difference** `sequence - ack`, stored in one byte. The decoder recovers
+`ack = sequence - difference`. This saves a byte whenever the far end is
+current, which is the common case.
+
+`ack_bits` bytes are written **low byte first**, and only those whose flag is
+set.
+
+### Canonical encoding is mandatory
+
+A given `(sequence, ack, ack_bits)` triple has exactly **one** legal encoding.
+A decoder that accepts a header must be able to re-encode it and get the
+identical bytes.
+
+The library enforces this for headers embedded in fragments: it re-encodes what
+it read and rejects the packet on any mismatch. An implementation that emits a
+non-minimal header — transmitting an `ack_bits` byte that happens to be `0xFF`,
+or a 16-bit `ack` when the difference fits in 8 bits — will produce packets
+that this library rejects.
+
+## Fragments
+
+A packet larger than the configured `fragment_above` threshold is split into
+fragments of `fragment_size` bytes each, up to `max_fragments` (256 maximum).
+
+### Fragment header
+
+    [prefix byte]       (uint8)     always exactly 1
+    [sequence]          (uint16)    the sequence of the whole packet
+    [fragment id]       (uint8)     0-based index of this fragment
+    [num fragments - 1] (uint8)     total count, stored minus one
+
+`num_fragments` is stored **minus one**, so a value of `0` means one fragment
+and `255` means 256. This is what allows 256 fragments in a single byte.
+
+Every fragment of a packet carries the same `sequence`.
+
+### The embedded packet header
+
+**Fragment 0 only** carries the packet header of the whole packet, immediately
+after the fragment header. Later fragments do not. So:
+
+    fragment 0:  [fragment header][packet header][fragment data]
+    fragment n:  [fragment header][fragment data]
+
+A receiver therefore learns the acknowledgement state of a fragmented packet
+only from fragment 0.
+
+The embedded header is subject to two additional checks: its `sequence` must
+equal the fragment header's `sequence`, and it must be canonically encoded, as
+above. Both failures reject the packet.
+
+All fragments except the last carry exactly `fragment_size` bytes of data. The
+last carries the remainder.
+
+## Receiver Obligations
+
+* Reject a packet too short to contain its header.
+* Reject a fragment whose `fragment_id >= num_fragments`, or whose
+  `num_fragments` exceeds the configured `max_fragments`.
+* Reject a non-canonical embedded header (see above).
+* Treat sequence numbers as wrapping; never compare them as plain integers.
+
+None of these are optional. Each is a place where a malformed or hostile packet
+would otherwise be accepted.
+
+## What This Format Does Not Do
+
+* **No retransmission.** reliable reports which packets arrived. Resending is
+  the caller's decision.
+* **No ordering.** Packets are delivered in arrival order.
+* **No encryption or authentication.** The header is plaintext and unprotected.
+  Anything that needs confidentiality or integrity must layer above or below.
+* **No connection state on the wire.** There is no handshake, no connection id,
+  and no session. Those belong to a higher layer — netcode, for instance.
+
+## Provenance
+
+Written 2026-07-21 by Rowan, by reading the reference implementation and
+verifying every claim differentially against it: headers generated by the
+library across a wide range of sequence, ack and ack_bits values were decoded
+by an independent implementation written only from this document, and required
+to agree on every field and on the exact encoded length.
+
+It documents the format as it stands; where this document and the
+implementation disagree, the implementation is authoritative and this document
+is a bug.
+
+The reference implementation is `reliable.c`.

--- a/reliable.c
+++ b/reliable.c
@@ -413,14 +413,6 @@ void reliable_write_uint64( uint8_t ** p, uint64_t value )
     *p += 8;
 }
 
-void reliable_write_bytes( uint8_t ** p, uint8_t * byte_array, int num_bytes )
-{
-    int i;
-    for ( i = 0; i < num_bytes; ++i )
-    {
-        reliable_write_uint8( p, byte_array[i] );
-    }
-}
 
 uint8_t reliable_read_uint8( uint8_t ** p )
 {
@@ -464,14 +456,6 @@ uint64_t reliable_read_uint64( uint8_t ** p )
     return value;
 }
 
-void reliable_read_bytes( uint8_t ** p, uint8_t * byte_array, int num_bytes )
-{
-    int i;
-    for ( i = 0; i < num_bytes; ++i )
-    {
-        byte_array[i] = reliable_read_uint8( p );
-    }
-}
 
 // ---------------------------------------------------------------
 

--- a/reliable.c
+++ b/reliable.c
@@ -2976,6 +2976,61 @@ static void test_endpoint_reset()
     }
 }
 
+static void test_rtt()
+{
+    double time = 100.0;
+    double delta_time = 0.01;
+
+    struct test_context_t context;
+    test_default_context(&context);
+
+    struct reliable_config_t sender_config;
+    struct reliable_config_t receiver_config;
+
+    reliable_default_config(&sender_config);
+    reliable_default_config(&receiver_config);
+
+    sender_config.context = &context;
+    sender_config.id = 0;
+    sender_config.transmit_packet_function = &test_transmit_packet_function;
+    sender_config.process_packet_function = &test_process_packet_function;
+
+    receiver_config.context = &context;
+    receiver_config.id = 1;
+    receiver_config.transmit_packet_function = &test_transmit_packet_function;
+    receiver_config.process_packet_function = &test_process_packet_function;
+
+    context.sender = reliable_endpoint_create(&sender_config, time);
+    context.receiver = reliable_endpoint_create(&receiver_config, time);
+
+    int i;
+    for (i = 0; i < 1000; ++i)
+    {
+        uint8_t dummy_packet[8];
+        memset(dummy_packet, 0, sizeof(dummy_packet));
+
+        reliable_endpoint_send_packet(context.sender, dummy_packet, sizeof(dummy_packet));
+        reliable_endpoint_send_packet(context.receiver, dummy_packet, sizeof(dummy_packet));
+
+        reliable_endpoint_update(context.sender, time);
+        reliable_endpoint_update(context.receiver, time);
+
+        time += delta_time;
+    }
+
+    float rtt = reliable_endpoint_rtt(context.sender);
+    float rtt_min = reliable_endpoint_rtt_min(context.sender);
+    float rtt_max = reliable_endpoint_rtt_max(context.sender);
+    float rtt_avg = reliable_endpoint_rtt_avg(context.sender);
+
+    check(rtt == rtt && rtt >= 0); // Check rtt is finite and non-negative
+    check(rtt_min >= 0 && rtt_min <= rtt_avg && rtt_avg <= rtt_max);
+    check(rtt_max < 1000.0); // Assume RTT is in milliseconds
+
+    reliable_endpoint_destroy(context.sender);
+    reliable_endpoint_destroy(context.receiver);
+}
+
 #define RUN_TEST( test_function )                                           \
     do                                                                      \
     {                                                                       \
@@ -3001,6 +3056,7 @@ void reliable_test()
         RUN_TEST( test_large_packets );
         RUN_TEST( test_sequence_buffer_rollover );
         RUN_TEST( test_fragment_cleanup );
+        RUN_TEST( test_rtt );
         RUN_TEST( test_endpoint_reset );
     }
 }

--- a/tools/conformance/README.md
+++ b/tools/conformance/README.md
@@ -1,0 +1,32 @@
+# Conformance: STANDARD.md vs the implementation
+
+`STANDARD.md` specifies reliable's wire format. `reliable.c` implements it. If
+they drift, independent implementations built from the document are wrong and
+nobody finds out until two of them refuse to talk.
+
+This checks them against each other. `gen_vectors.c` links the real library and
+emits artifacts; `verify_standard.py` parses them using **only what STANDARD.md
+says**, with no reference to `reliable.c`, and asserts every field.
+
+    python3 tools/conformance/verify_standard.py
+
+Exit 0 means the document and the code agree. A failure means one of them is
+wrong — decide which, and fix that one.
+
+## What is covered
+
+* **packet headers** — 512 vectors across the corners of the elision rules:
+  sequence/ack wrap, difference at exactly 255 and 256, `ack_bits` all-set,
+  none-set and mixed. Every field plus the **exact byte length**, because a
+  subtly wrong elision rule still decodes correctly while consuming the wrong
+  number of bytes and desynchronizing everything after it.
+* **fragment headers** — real fragments from a real endpoint: the prefix byte
+  of exactly 1, fragment ids, `num_fragments` stored minus one, the shared
+  sequence, that **only fragment 0 carries the embedded packet header**, and
+  that data sizes are `fragment_size` except for the remainder in the last.
+
+## What is NOT covered
+
+Endpoint behaviour above the wire: ack logic, reassembly state, RTT and
+counters. Those are the library's semantics rather than its format, and
+`test.cpp` is where they belong.

--- a/tools/conformance/gen_vectors.c
+++ b/tools/conformance/gen_vectors.c
@@ -1,0 +1,65 @@
+/*
+    Emits wire artifacts from the real library for tools/conformance/verify_standard.py.
+    Two kinds:
+      HDR  <sequence> <ack> <ack_bits> <bytes>   — reliable_write_packet_header output
+      FRAG <sequence> <fragment_id> <num_fragments> <bytes> — a real fragment off the wire
+*/
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include "reliable.h"
+
+int reliable_write_packet_header( uint8_t *, uint16_t, uint16_t, uint32_t );
+
+static void hex( uint8_t * b, int n ) { for ( int i = 0; i < n; i++ ) printf( "%02x", b[i] ); }
+
+static int frag_count = 0;
+static void on_transmit( void * ctx, uint64_t id, uint16_t seq, uint8_t * data, int bytes )
+{
+    (void) ctx; (void) id; (void) seq;
+    printf( "FRAG %d ", frag_count++ );
+    hex( data, bytes );
+    printf( "\n" );
+}
+static int on_process( void * ctx, uint64_t id, uint16_t seq, uint8_t * data, int bytes )
+{ (void) ctx; (void) id; (void) seq; (void) data; (void) bytes; return 1; }
+
+int main( void )
+{
+    reliable_init();
+
+    /* packet headers across the interesting corners of the elision rules */
+    uint16_t seqs[] = { 0, 1, 255, 256, 1000, 32768, 65535, 7 };
+    uint16_t acks[] = { 0, 1, 254, 255, 256, 999, 65535, 32760 };
+    uint32_t bits[] = { 0xFFFFFFFF, 0x00000000, 0xFFFFFF00, 0x00FFFFFF,
+                        0xDEADBEEF, 0xFF00FF00, 0x000000FF, 0xFFFF00FF };
+    uint8_t buf[64];
+    for ( int a = 0; a < 8; a++ )
+    for ( int b = 0; b < 8; b++ )
+    for ( int c = 0; c < 8; c++ )
+    {
+        int n = reliable_write_packet_header( buf, seqs[a], acks[b], bits[c] );
+        printf( "HDR %u %u %u ", seqs[a], acks[b], bits[c] );
+        hex( buf, n );
+        printf( "\n" );
+    }
+
+    /* real fragments: a packet well above the fragment threshold */
+    struct reliable_config_t config;
+    reliable_default_config( &config );
+    config.fragment_above = 500;
+    config.fragment_size = 500;
+    config.max_fragments = 16;
+    config.max_packet_size = 8 * 1024;
+    config.transmit_packet_function = on_transmit;
+    config.process_packet_function = on_process;
+    struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &config, 0.0 );
+    if ( !endpoint ) { fprintf( stderr, "endpoint create failed\n" ); return 1; }
+    uint8_t payload[2200];
+    for ( int i = 0; i < (int) sizeof( payload ); i++ ) payload[i] = (uint8_t) ( i * 7 );
+    reliable_endpoint_send_packet( endpoint, payload, sizeof( payload ) );
+    printf( "FRAGINFO %d %d\n", (int) sizeof( payload ), config.fragment_size );
+    reliable_endpoint_destroy( endpoint );
+    reliable_term();
+    return 0;
+}

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -17,7 +17,7 @@ def build_and_run(cc):
     src = os.path.join(ROOT, "tools", "conformance", "gen_vectors.c")
     with tempfile.TemporaryDirectory() as tmp:
         exe = os.path.join(tmp, "gen")
-        r = subprocess.run([cc, "-I" + ROOT, "-o", exe, src, os.path.join(ROOT, "reliable.c")],
+        r = subprocess.run([cc, "-I" + ROOT, "-o", exe, src, os.path.join(ROOT, "reliable.c"), "-lm"],
                            capture_output=True, text=True)
         if r.returncode != 0:
             print("build failed:\n" + r.stderr[:2000], file=sys.stderr); sys.exit(2)

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -82,6 +82,8 @@ def main():
             c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: ack", da, ack)
             c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: ack_bits", dab, bits)
             c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: consumed all bytes", dn, len(raw))
+            c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: length within 4..9",
+                 4 <= len(raw) <= 9, True)
         elif f[0] == "FRAG":
             frags.append(bytes.fromhex(f[2]))
         elif f[0] == "FRAGINFO":
@@ -94,6 +96,7 @@ def main():
 
     for idx, raw in enumerate(frags):
         seq, fid, nfrags, consumed = decode_fragment_header(raw)
+        c.eq(f"fragment {idx}: fragment header is exactly 5 bytes", consumed, 5)
         c.eq(f"fragment {idx}: prefix byte is 1", raw[0], 1)
         c.eq(f"fragment {idx}: fragment id", fid, idx)
         c.eq(f"fragment {idx}: num_fragments (stored minus one)", nfrags, expected_frags)

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Check reliable/STANDARD.md against the implementation.
+
+Parses artifacts produced by the real library using ONLY what STANDARD.md
+states. Nothing here consults reliable.c. If the document and the code
+disagree, this fails and one of them is wrong.
+
+usage: python3 tools/conformance/verify_standard.py [--cc CC]
+exit:  0 = they agree, 1 = they do not, 2 = could not build/run
+"""
+import argparse, os, subprocess, sys, tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def build_and_run(cc):
+    src = os.path.join(ROOT, "tools", "conformance", "gen_vectors.c")
+    with tempfile.TemporaryDirectory() as tmp:
+        exe = os.path.join(tmp, "gen")
+        r = subprocess.run([cc, "-I" + ROOT, "-o", exe, src, os.path.join(ROOT, "reliable.c")],
+                           capture_output=True, text=True)
+        if r.returncode != 0:
+            print("build failed:\n" + r.stderr[:2000], file=sys.stderr); sys.exit(2)
+        r = subprocess.run([exe], capture_output=True, text=True)
+        if r.returncode != 0:
+            print("generator failed:\n" + r.stderr[:2000], file=sys.stderr); sys.exit(2)
+        return r.stdout
+
+
+class Checker:
+    def __init__(self): self.n = 0; self.fails = []
+    def eq(self, name, got, exp):
+        self.n += 1
+        if got != exp: self.fails.append(f"{name}: got {got!r}, STANDARD.md says {exp!r}")
+
+
+def decode_packet_header(b):
+    """STANDARD.md, 'Packet Header'. Returns (sequence, ack, ack_bits, bytes_consumed)."""
+    i = 0
+    prefix = b[i]; i += 1
+    if prefix & 1:
+        raise ValueError("bit 0 set: this is a fragment, not a regular packet")
+    seq = b[i] | (b[i + 1] << 8); i += 2
+    if prefix & (1 << 5):                       # ack stored as a one-byte difference
+        ack = (seq - b[i]) & 0xFFFF; i += 1
+    else:
+        ack = b[i] | (b[i + 1] << 8); i += 2
+    ack_bits = 0
+    for n, flag in enumerate((1, 2, 3, 4)):     # a SET flag means the byte is PRESENT
+        if prefix & (1 << flag):
+            ack_bits |= b[i] << (8 * n); i += 1
+        else:
+            ack_bits |= 0xFF << (8 * n)
+    return seq, ack, ack_bits, i
+
+
+def decode_fragment_header(b):
+    """STANDARD.md, 'Fragments'. Returns (sequence, fragment_id, num_fragments, consumed)."""
+    i = 0
+    prefix = b[i]; i += 1
+    if prefix != 1:
+        raise ValueError(f"fragment prefix byte must be exactly 1, got {prefix}")
+    seq = b[i] | (b[i + 1] << 8); i += 2
+    frag_id = b[i]; i += 1
+    num_frags = b[i] + 1; i += 1               # stored MINUS ONE
+    return seq, frag_id, num_frags, i
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--cc", default=os.environ.get("CC", "cc"))
+    a = ap.parse_args()
+    c = Checker()
+    frags = []; fraginfo = None
+
+    for line in build_and_run(a.cc).splitlines():
+        f = line.split()
+        if f[0] == "HDR":
+            seq, ack, bits, raw = int(f[1]), int(f[2]), int(f[3]), bytes.fromhex(f[4])
+            ds, da, dab, dn = decode_packet_header(raw)
+            c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: sequence", ds, seq)
+            c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: ack", da, ack)
+            c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: ack_bits", dab, bits)
+            c.eq(f"header seq={seq} ack={ack} bits={bits:#010x}: consumed all bytes", dn, len(raw))
+        elif f[0] == "FRAG":
+            frags.append(bytes.fromhex(f[2]))
+        elif f[0] == "FRAGINFO":
+            fraginfo = (int(f[1]), int(f[2]))
+
+    # ---- fragments
+    payload_bytes, fragment_size = fraginfo
+    expected_frags = (payload_bytes + fragment_size - 1) // fragment_size
+    c.eq("number of fragments emitted", len(frags), expected_frags)
+
+    for idx, raw in enumerate(frags):
+        seq, fid, nfrags, consumed = decode_fragment_header(raw)
+        c.eq(f"fragment {idx}: prefix byte is 1", raw[0], 1)
+        c.eq(f"fragment {idx}: fragment id", fid, idx)
+        c.eq(f"fragment {idx}: num_fragments (stored minus one)", nfrags, expected_frags)
+        c.eq(f"fragment {idx}: same sequence as fragment 0", seq, decode_fragment_header(frags[0])[0])
+        if idx == 0:
+            # STANDARD.md: fragment 0 ALONE carries the packet header
+            hs, ha, hab, hn = decode_packet_header(raw[consumed:])
+            c.eq("fragment 0: embedded header sequence equals fragment sequence", hs, seq)
+            data = len(raw) - consumed - hn
+            c.eq("fragment 0: data is exactly fragment_size", data, fragment_size)
+        else:
+            data = len(raw) - consumed
+            expect = fragment_size if idx < expected_frags - 1 else payload_bytes % fragment_size
+            c.eq(f"fragment {idx}: data size", data, expect)
+            # later fragments must NOT carry a packet header
+            c.eq(f"fragment {idx}: no embedded header (size accounts for data alone)",
+                 len(raw), consumed + expect)
+
+    print(f"{c.n} checks against STANDARD.md, {len(c.fails)} failures")
+    for x in c.fails[:15]: print("  FAIL " + x)
+    if c.fails:
+        print("\nSTANDARD.md and the implementation disagree. One of them is wrong.")
+        return 1
+    print("\nSTANDARD.md matches the implementation.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
reliable had no format documentation at all — 154 lines of README with zero mentions of the wire format.

**STANDARD.md** — the two packet shapes, the variable-length 4-to-9-byte packet header, the prefix-byte elision scheme (a set flag means the `ack_bits` byte is *present*; absent means substitute `0xFF`), the one-byte ack difference, and fragment headers with `num_fragments` stored minus one so 256 fits in a byte. Also records that **canonical encoding is mandatory** — the library re-encodes embedded headers and rejects any byte mismatch.

**tools/conformance** — 2,596 checks. 512 header vectors across the corners of the elision rules, plus real fragments from a real endpoint. Every check asserts the exact byte length as well as the field values, because a subtly wrong elision rule still decodes correct-looking fields while consuming the wrong number of bytes.

**Dead code removed** — `reliable_read_bytes` / `reliable_write_bytes`, neither declared in the header nor called anywhere.

Not a byte changes on the wire. No release accompanies this.