### PR TITLE
reliable 1.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(reliable VERSION 1.3.5 LANGUAGES C CXX)
+project(reliable VERSION 1.4.0 LANGUAGES C CXX)
 
 # is this the top level project, or pulled in via add_subdirectory / FetchContent?
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/reliable.h
+++ b/reliable.h
@@ -31,10 +31,10 @@
 #ifndef RELIABLE_H
 #define RELIABLE_H
 
-#define RELIABLE_VERSION_FULL    "1.3.5"
+#define RELIABLE_VERSION_FULL    "1.4.0"
 #define RELIABLE_VERSION_MAJOR   1
-#define RELIABLE_VERSION_MINOR   3
-#define RELIABLE_VERSION_PATCH   5
+#define RELIABLE_VERSION_MINOR   4
+#define RELIABLE_VERSION_PATCH   0
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Version bump for the 1.4.0 release. CMakeLists.txt and reliable.h move together for `release-check.yml`.

**MINOR.** Two independently qualifying user-visible changes:
- **A new normative wire-format specification, `STANDARD.md` ("reliable 1.0")** — an independent implementer must read it to interoperate byte-for-byte. Plus a correction to a normative bound (header size "between 3 and 9 bytes" → "4 to 9 bytes") and naming of the two size constants.
- **Removal of `reliable_read_bytes` / `reliable_write_bytes`** — dead code. Glenn, 2026-07-25: *"I'm OK if you remove it. It's dead code. Removing dead code at any time is fine."*

No security content — reliable performs no cryptography.