### PR TITLE
CLAUDE.md: add the HOT block — decisions that read as bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,30 @@
+<!-- HOT:BEGIN -->
+## HOT — read before reasoning about this repo
+
+WHAT: the C reference for reliable — packet fragmentation, reassembly and acks over an
+unreliable transport. NOT reliable.rs / reliable.go (the ports).
+
+DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
+- **Release builds trust the caller. This is the design contract**, confirmed with the
+  maintainer 2026-07: correct configuration is the programmer's responsibility in release.
+  Debug asserts catch bad config during development; release deliberately carries no
+  validation overhead. Do NOT add release-mode config checks or defensive branches — that
+  includes the tempting ones like `max_fragments > 256` (which would overflow
+  `fragment_received[256]`). Adding them is fighting the library, not hardening it.
+- **No authentication, no anti-spoofing, and that is out of scope.** reliable assumes an
+  authenticated encrypted transport beneath it — that is netcode's job. Forged packets,
+  window-warping via a fake far-future sequence, spoofed acks: all netcode's to prevent.
+  Do not add defenses here.
+- **Fragmentation amplifies loss on purpose.** One lost fragment loses the whole packet,
+  and in-progress reassemblies evicted by newer traffic are the same trade. Latency comes
+  first. Callers needing large reliable blocks build block transfer above this (yojimbo
+  does exactly that) rather than sending very large packets.
+- **No keepalives, because there are never lulls.** reliable assumes continuous
+  bidirectional exchange at ~60Hz; acks piggyback on outgoing packets. One-directional or
+  bursty request/response traffic is out of scope, and the rtt/jitter/loss stats are fresh
+  only under that same assumption.
+<!-- HOT:END -->
+
 # CLAUDE.md
 
 ## What this is


### PR DESCRIPTION
Coverage was 6/12 across the lane and **the four flagship C libraries were the gap** — the worst possible place for it, since these are the repos most likely to be reasoned about by someone who did not write them.

### Distilled, not invented

Every item in the block was already documented somewhere in this file. The hot block is the part a stranger must read **first**, pulled to the top with `file:line` where the code says so itself. Nothing here is a new claim.

It answers one question: **what in this repo looks like a defect and is not?**

That is the exact failure this mechanism exists to stop. I recently reported `netcode.rs`'s `netcode-official` crate name to Glenn as a defect — when it was a deliberate workaround already written down in that repo's hot block, which I had not read.

### Things that would otherwise get "fixed"

- flat linear scans chosen **over** a hash map, because an attacker controls the keys (source addresses) and could drive a hash into its worst case
- release builds that deliberately carry no config validation — the caller is trusted by design
- serialize macros that hide `return false` on purpose, because invalid data must abort before any attacker-bounded loop
- debug asserts deliberately kept **off** the untrusted read path, so a hostile peer cannot crash a debug server

Glenn, emphatic: the per-repo hot block and the per-bud queue are *"the most important things while you work."*