### PR TITLE
Build strict: -ffp-contract=off replaces -ffast-math on every target

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -28,6 +28,23 @@ To build with AddressSanitizer and UndefinedBehaviorSanitizer (recommended when 
 
     cmake -B build -DCMAKE_BUILD_TYPE=Debug -DRELIABLE_SANITIZE=ON
 
+## Floating point: reliable builds with -ffp-contract=off
+
+Estate policy for mas-bandwidth network libraries: builds are strict about floating point
+contraction. This build sets the right flag on every target, so nothing is required of you to
+build reliable itself:
+
+  - GCC/Clang: `-ffp-contract=off`. Not merely the absence of `-ffast-math` — GCC's default
+    is `-ffp-contract=fast`, which contracts across statement boundaries, and clang's default
+    `=on` still fuses within a single expression.
+  - MSVC: `/fp:precise`.
+
+reliable's wire format carries no floating point, so no flag is required of consumers for
+correct wire bytes today. The strict build is the family floor: contraction is
+architecture-dependent (FMA is in the aarch64 baseline and absent from the x86-64 one), so
+float arithmetic near a wire diverges bit-wise between architectures without it. If you
+compile `reliable.c` into your own build rather than linking the library, carry the same flag.
+
 ## Building on Windows
 
 You need Visual Studio with the C++ workload installed (CMake is included, or install it separately).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,14 @@ set_target_properties(reliable PROPERTIES
     SOVERSION ${PROJECT_VERSION_MAJOR}
     WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
+# reliable.c calls pow() for the jitter stddev, which needs libm where it is a separate
+# library (Linux glibc; on mac and Windows the math functions live in the base runtime).
+# PUBLIC so every executable linking the static library gets it on its link line.
+find_library(RELIABLE_MATH_LIBRARY m)
+if(RELIABLE_MATH_LIBRARY)
+    target_link_libraries(reliable PUBLIC ${RELIABLE_MATH_LIBRARY})
+endif()
+
 if(RELIABLE_BUILD_TESTS)
 
     # "test" is a reserved target name in cmake, so the target is reliable_test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,22 @@ endif()
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+# strict floating point. Estate policy for mas-bandwidth network libraries: "generally
+# speaking, network libraries we work on require -ffp-contract=off" (Glenn, 2026-08-24).
+#   - GCC/Clang: -ffp-contract=off. Not merely "no -ffast-math" -- GCC's default is
+#     -ffp-contract=fast, which contracts across statements, and clang's default =on still
+#     fuses within a single expression.
+#   - MSVC: /fp:precise, which since VS 2022 does not imply contraction.
+# reliable's wire format carries no floating point -- the floats here are the RTT, jitter,
+# packet loss and bandwidth stats -- so this is the family floor rather than a wire fix:
+# contraction is architecture-dependent (FMA is in the aarch64 baseline and absent from
+# the x86-64 one), so any float arithmetic that ever nears the wire diverges bit-wise
+# between architectures without it. CI builds through this file, so every CI leg builds
+# with these flags.
 if(MSVC)
-    add_compile_options(/W4 /fp:fast)
+    add_compile_options(/W4 /fp:precise)
 else()
-    add_compile_options(-Wall -Wextra -ffast-math)
+    add_compile_options(-Wall -Wextra -ffp-contract=off)
 endif()
 
 if(RELIABLE_SANITIZE)

--- a/reliable.pc.in
+++ b/reliable.pc.in
@@ -7,4 +7,5 @@ Description: Simple packet acknowledgement system for UDP-based protocols
 URL: https://github.com/mas-bandwidth/reliable
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lreliable
+Libs.private: -lm
 Cflags: -I${includedir}


### PR DESCRIPTION
Enacts Glenn's standing estate policy (2026-08-24): *"generally speaking, network libraries we work on require -ffp-contract=off."* serialize sets and documents the flag; yojimbo came under the policy in mas-bandwidth/yojimbo#333; netcode's equivalent is mas-bandwidth/netcode#179. This brings reliable under it.

CMakeLists.txt replaces the global `-ffast-math` (GCC/Clang) and `/fp:fast` (MSVC) with `-ffp-contract=off` and `/fp:precise`. Global `add_compile_options`, so every target — library, test, example, soak, stats, fuzz harnesses — builds strict, and since CI drives every leg through this file, CI now enforces the flag on all platforms. BUILDING.md gains a floating point section mirroring yojimbo's, stating the flags and the consumer requirement.

Honesty about scope: reliable's wire format carries no floating point — the floats in reliable.c are the RTT, jitter, packet loss and bandwidth stats. So this is the policy's floor, not a wire fix; nothing measured wrong here today, and the docs say exactly that rather than claiming a mechanism this repo does not have. The floor exists because FMA is in the aarch64 baseline and absent from the x86-64 one, so any float arithmetic that ever nears the wire diverges bit-wise between architectures unless the family builds strict.

The fast-math flags date from the premake era; serialize made the same replacement, and on MSVC there is no fast-minus-contraction spelling at all, so strict-replaces-fast is the only shape consistent across compilers.

Verified on this bench (arm64 mac, AppleClang, Release): build green, all 4 ctest suites pass (test, fuzz, soak, fuzz_target), `-ffp-contract=off` confirmed on the actual compile lines of `reliable.c` and `test.cpp` via `cmake --build --verbose`, zero remaining `ffast-math` occurrences in the build output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)