### PR TITLE
reliable 1.4.1: the header and CMake carry the new version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(reliable VERSION 1.4.0 LANGUAGES C CXX)
+project(reliable VERSION 1.4.1 LANGUAGES C CXX)
 
 # is this the top level project, or pulled in via add_subdirectory / FetchContent?
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/reliable.h
+++ b/reliable.h
@@ -32,10 +32,10 @@
 #ifndef RELIABLE_H
 #define RELIABLE_H
 
-#define RELIABLE_VERSION_FULL    "1.4.0"
+#define RELIABLE_VERSION_FULL    "1.4.1"
 #define RELIABLE_VERSION_MAJOR   1
 #define RELIABLE_VERSION_MINOR   4
-#define RELIABLE_VERSION_PATCH   0
+#define RELIABLE_VERSION_PATCH   1
 
 #include <stdint.h>
 #include <stddef.h>


### PR DESCRIPTION
Version bump for the 1.4.1 release: strict floating-point builds (-ffp-contract=off / /fp:precise) on every target, libm linked where strict math keeps the real pow() call, SECURITY.md added.