### PR TITLE
A no-op build prints nothing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.15)
 
+# A no-op build prints nothing (rowan-new#110). The per-target "Built target" lines are
+# the only output a rebuild with nothing to do produces, and they carry no information; a
+# real build still prints its [ x%] progress lines, and errors are untouched. This sits
+# above project() because CMAKE_TARGET_MESSAGES initializes the TARGET_MESSAGES global
+# property there and has no effect if set after it, and under the same top-level test as the
+# RELIABLE_TOP_LEVEL guard below, so a consumer that pulls this library in through FetchContent
+# keeps its own messages.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CMAKE_TARGET_MESSAGES OFF)
+endif()
+
 project(reliable VERSION 1.4.1 LANGUAGES C CXX)
 
 # is this the top level project, or pulled in via add_subdirectory / FetchContent?


### PR DESCRIPTION
One line does it:

    set(CMAKE_TARGET_MESSAGES OFF)

It sits above project(), wrapped in the same top-level test the RELIABLE_TOP_LEVEL
guard uses, so it applies only when this repo is the top level project and a
consumer that pulls the library in through FetchContent or add_subdirectory keeps
its own "Built target" messages.

Above project(), not inside the existing top-level branch: CMAKE_TARGET_MESSAGES
initializes the TARGET_MESSAGES global property at the project() call and has no
effect if set after it. Placed inside the branch, a no-op rebuild still printed all
7 lines -- which is why the line carries its own guard rather than joining the one
below.

Before / after, on a tree with nothing to do:

    $ cmake --build build | wc -l
    7   # before
    0   # after

A real build is unchanged: it still prints its [ x%] progress lines. Errors are
untouched -- a deliberate syntax error in a source file still fails loudly with the
compiler diagnostic and a non-zero exit (verified, then reverted).

Tests: ctest --test-dir build --output-on-failure -> 100% tests passed out of 4

Refs mas-bandwidth/rowan-new#110.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
