### PR TITLE
reliable 1.4.2: endpoint contracts, a bounded export surface and a C only build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,17 @@ WHAT: the C reference for reliable — packet fragmentation, reassembly and acks
 unreliable transport. NOT reliable.rs / reliable.go (the ports).
 
 DECISIONS THAT READ AS BUGS (they are not — do not "fix" them)
-- **Release builds trust the caller. This is the design contract**, confirmed with the
-  maintainer 2026-07: correct configuration is the programmer's responsibility in release.
-  Debug asserts catch bad config during development; release deliberately carries no
-  validation overhead. Do NOT add release-mode config checks or defensive branches — that
-  includes the tempting ones like `max_fragments > 256` (which would overflow
-  `fragment_received[256]`). Adding them is fighting the library, not hardening it.
+- **Release builds trust the caller on the hot paths. This is the design contract.**
+  Correct arguments to send, receive and copy are the programmer's responsibility in
+  release; debug asserts catch mistakes during development and release carries no
+  per-packet validation overhead. Do NOT add release-mode checks to those paths.
+- **Endpoint creation is the exception and is fallible in every build.**
+  `reliable_endpoint_create` validates the whole config, checks the size arithmetic, checks
+  every allocation, frees whatever it took, and returns NULL. Creation happens once, off the
+  hot path, and the header and README both promise a NULL check, so the promise is kept
+  rather than left to an assert release compiles out. `reliable_endpoint_destroy` checks
+  each member rather than asserting it, because create hands it a partly built endpoint to
+  unwind. Do not turn any of this back into asserts.
 - **No authentication, no anti-spoofing, and that is out of scope.** reliable assumes an
   authenticated encrypted transport beneath it — that is netcode's job. Forged packets,
   window-warping via a fake far-future sequence, spoofed acks: all netcode's to prevent.
@@ -41,8 +46,6 @@ contract, not a bug:
     > max_packet_size test at :768 is false for negatives, so it reaches the memcpy at
     :802 and the int becomes a huge size_t. Proved under ASan (negative-size-param).
     Note netcode's equivalent DOES range-check; that difference is not a defect here.
-  - the config asserts in reliable_endpoint_create (reliable.c:561-572), including
-    max_fragments <= 256 with no runtime companion.
 THE RECEIVE PATH IS CLEAN AND UNUSUALLY WELL HARDENED -- two independent audits (Opus 5 and
 Fable 5) agree. read_fragment_header checks minimum length (:963), num_fragments >
 max_fragments (:982), fragment_id >= num_fragments (:988), fragment_bytes (:1038, :1044);
@@ -107,17 +110,21 @@ The findings from that 2026-07 review are recorded below; everything actionable 
 fixed at the time (see "Found and fixed"). What remains is the design contract and the
 gotchas — read those before changing anything.
 
-### Design contract: release builds trust the caller (do not "fix" this)
+### Design contract: release builds trust the caller on the hot paths (do not "fix" this)
 
-Per the maintainer (2026-07): **correct configuration is the programmer's responsibility
-in release.** Debug asserts exist to help the programmer catch bad configuration during
-development; release builds deliberately carry no validation overhead. Do not add
-release-mode config checks or defensive branches — that would be fighting the library's
-design. Concretely, this covers things like `max_fragments > 256` (would overflow
-`fragment_received[256]` on the receive path) and inconsistent
-`max_packet_size > max_fragments * fragment_size`: real caller errors, caught by asserts
-in debug, the caller's problem in release. The same trust model applies to allocators —
-the caller supplies them and is responsible for them not failing.
+**Correct arguments are the programmer's responsibility in release.** Debug asserts exist
+to help the programmer catch mistakes during development; release builds deliberately
+carry no per-packet validation overhead. Do not add release-mode checks to the send,
+receive or copy paths.
+
+Endpoint creation is the one place that validates in every build. It runs once, off the
+hot path, and both the header and the README promise the caller a NULL check, so
+`reliable_endpoint_create` validates the config (every field range plus the two
+relationships, `fragment_above` against `max_packet_size` and `max_fragments *
+fragment_size` covering `max_packet_size`), checks the size arithmetic behind every
+buffer, checks every allocation result, frees what it already took and returns NULL. The
+caller supplies the allocator, and an allocator that returns NULL is a supported outcome
+rather than undefined behavior.
 
 ### Open issues
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,10 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     set(CMAKE_TARGET_MESSAGES OFF)
 endif()
 
-project(reliable VERSION 1.4.1 LANGUAGES C CXX)
+# C only. the library is C99 and nothing in it needs a C++ compiler; the test driver is the
+# one C++ translation unit in the tree, so CXX is enabled below only when tests are built.
+# a consumer that has no C++ compiler configures and builds with -DRELIABLE_BUILD_TESTS=OFF
+project(reliable VERSION 1.4.2 LANGUAGES C)
 
 # is this the top level project, or pulled in via add_subdirectory / FetchContent?
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -23,8 +26,15 @@ endif()
 option(RELIABLE_SANITIZE "Build with AddressSanitizer and UndefinedBehaviorSanitizer" OFF)
 option(RELIABLE_BUILD_TESTS "Build reliable tests, examples and harnesses" ${RELIABLE_TOP_LEVEL})
 
-# default to debug, same as the old premake makefiles
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+# test.cpp is the only C++ in the tree
+if(RELIABLE_BUILD_TESTS)
+    enable_language(CXX)
+endif()
+
+# default to debug, same as the old premake makefiles. only when this is the top level
+# project: a consumer that pulls the library in through add_subdirectory or FetchContent
+# picks its own build type, and forcing the cache variable would overwrite it
+if(RELIABLE_TOP_LEVEL AND NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     set(CMAKE_BUILD_TYPE Debug CACHE STRING "Build type" FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS Debug Release)
 endif()
@@ -71,6 +81,8 @@ endif()
 
 add_library(reliable reliable.c reliable.h)
 
+target_compile_features(reliable PUBLIC c_std_99)
+
 target_include_directories(reliable PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>)
@@ -81,10 +93,19 @@ target_compile_definitions(reliable
         $<$<CONFIG:Release>:RELIABLE_RELEASE>
 )
 
+# the public surface is the RELIABLE_EXPORT declarations in reliable.h and nothing else.
+# hidden visibility plus the export macro means a shared build exports exactly those, on every
+# platform, rather than every global the compiler happens to emit
 set_target_properties(reliable PROPERTIES
     VERSION ${PROJECT_VERSION}
     SOVERSION ${PROJECT_VERSION_MAJOR}
-    WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON)
+
+if(BUILD_SHARED_LIBS)
+    target_compile_definitions(reliable PUBLIC RELIABLE_SHARED)
+    target_compile_definitions(reliable PRIVATE RELIABLE_BUILDING)
+endif()
 
 # reliable.c calls pow() for the jitter stddev, which needs libm where it is a separate
 # library (Linux glibc; on mac and Windows the math functions live in the base runtime).
@@ -127,6 +148,30 @@ if(RELIABLE_BUILD_TESTS)
     add_test(NAME fuzz COMMAND fuzz 20000 12345)
     add_test(NAME soak COMMAND soak 8192 --quiet)
     add_test(NAME fuzz_target COMMAND fuzz_target_standalone 500 12345)
+
+    # the library must export exactly the RELIABLE_EXPORT surface of reliable.h and nothing
+    # else. needs nm to read the symbol table, so it runs where nm exists
+    find_program(RELIABLE_NM nm)
+    if(RELIABLE_NM)
+        add_test(NAME symbols COMMAND ${CMAKE_COMMAND}
+            -DRELIABLE_LIBRARY=$<TARGET_FILE:reliable>
+            -DRELIABLE_HEADER=${CMAKE_CURRENT_SOURCE_DIR}/reliable.h
+            -DRELIABLE_NM=${RELIABLE_NM}
+            -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/symbols/check_symbols.cmake)
+    endif()
+
+    # the header's own promises: const views, and a documented lifetime for every pointer a
+    # callback receives
+    add_test(NAME header_contract COMMAND ${CMAKE_COMMAND}
+        -DRELIABLE_HEADER=${CMAKE_CURRENT_SOURCE_DIR}/reliable.h
+        -P ${CMAKE_CURRENT_SOURCE_DIR}/tools/symbols/check_header.cmake)
+
+    # configuring with tests off must not need a C++ compiler
+    add_test(NAME configure_without_cxx COMMAND ${CMAKE_COMMAND}
+        -S ${CMAKE_CURRENT_SOURCE_DIR}
+        -B ${CMAKE_CURRENT_BINARY_DIR}/configure_without_cxx
+        -DRELIABLE_BUILD_TESTS=OFF
+        -DCMAKE_CXX_COMPILER=reliable-has-no-cxx-compiler)
 
 endif()
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ if ( endpoint == NULL )
 }
 ```
 
+`reliable_endpoint_create` returns NULL, in debug and release alike, if the config is not
+valid or if an allocation fails, and it frees everything it took before it does. Check the
+result.
+
 For example, in a client/server setup you would have one endpoint on each client, and n endpoints on the server, one for each client slot.
 
 Next, create a function to transmit packets:
@@ -84,7 +88,7 @@ And get acks like this:
 
 ```c
 int num_acks;
-uint16_t * acks = reliable_endpoint_get_acks( endpoint, &num_acks );
+const uint16_t * acks = reliable_endpoint_get_acks( endpoint, &num_acks );
 for ( int i = 0; i < num_acks; i++ )
 {
     printf( "acked packet %d\n", acks[i] );
@@ -133,6 +137,10 @@ reliable is a packet acknowledgement system, not a full messaging layer. Keep th
 1. Acks accumulate until you call `reliable_endpoint_clear_acks`, so make sure you clear acks once you have processed them each frame. If the ack buffer fills up, additional acks are dropped and an error is logged.
 
 2. Endpoints are not thread safe. Use one endpoint per-thread, or protect each endpoint with your own lock. The log level, printf and assert handlers are global to the process.
+
+3. Every pointer a callback receives is valid only for the duration of the call, and the ack array `reliable_endpoint_get_acks` returns is a read only view that the next receive, clear, reset or destroy invalidates. Copy what you need to keep. `reliable.h` states the lifetime of each one.
+
+4. The transmit packet callback must not send on the same endpoint it was called from. It runs while that endpoint's transmit buffer is in use. Sending on a different endpoint is fine, as is sending from the process packet callback.
 
 # Author
 

--- a/example.c
+++ b/example.c
@@ -138,7 +138,7 @@ int main( int argc, char ** argv )
         printf( "%d: client sent packet %d\n", i, client_packet_sequence );
 
         int num_acks;
-        uint16_t * acks = reliable_endpoint_get_acks( client.endpoint, &num_acks );
+        const uint16_t * acks = reliable_endpoint_get_acks( client.endpoint, &num_acks );
         for ( int j = 0; j < num_acks; j++ )
         {
             printf( " --> server acked packet %d\n", acks[j] );

--- a/reliable.c
+++ b/reliable.c
@@ -30,6 +30,7 @@
 #include <stdarg.h>
 #include <inttypes.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 
 #ifndef RELIABLE_ENABLE_TESTS
@@ -45,6 +46,7 @@
 static void default_assert_handler( RELIABLE_CONST char * condition, RELIABLE_CONST char * function, RELIABLE_CONST char * file, int line )
 {
     printf( "assert failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
+    fflush( stdout );
     #if defined( __GNUC__ )
     __builtin_trap();
     #elif defined( _MSC_VER )
@@ -75,7 +77,7 @@ void reliable_set_assert_function( void (*function)( RELIABLE_CONST char *, RELI
 
 #if RELIABLE_ENABLE_LOGGING
 
-void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
+static void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
 {
     if ( level > log_level )
         return;
@@ -89,7 +91,7 @@ void reliable_printf( int level, RELIABLE_CONST char * format, ... )
 
 #else // #if RELIABLE_ENABLE_LOGGING
 
-void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
+static void reliable_printf( int level, RELIABLE_CONST char * format, ... ) 
 {
     (void) level;
     (void) format;
@@ -97,16 +99,35 @@ void reliable_printf( int level, RELIABLE_CONST char * format, ... )
 
 #endif // #if RELIABLE_ENABLE_LOGGING
 
-void * reliable_default_allocate_function( void * context, size_t bytes )
+static void * reliable_default_allocate_function( void * context, size_t bytes )
 {
     (void) context;
     return malloc( bytes );
 }
 
-void reliable_default_free_function( void * context, void * pointer )
+static void reliable_default_free_function( void * context, void * pointer )
 {
     (void) context;
     free( pointer );
+}
+
+// multiplies an element count by an element size for an allocation. returns 0 if the count is
+// negative or the product does not fit in a size_t, so a config that would wrap the arithmetic
+// is refused instead of allocating a buffer smaller than the code goes on to use
+
+static int reliable_checked_size( int count, size_t element_bytes, size_t * result )
+{
+    reliable_assert( result );
+    if ( count <= 0 || element_bytes == 0 )
+    {
+        return 0;
+    }
+    if ( (size_t) count > SIZE_MAX / element_bytes )
+    {
+        return 0;
+    }
+    *result = ( (size_t) count ) * element_bytes;
+    return 1;
 }
 
 // ------------------------------------------------------------------
@@ -122,13 +143,13 @@ void reliable_term(void)
 
 // ---------------------------------------------------------------
 
-int reliable_sequence_greater_than( uint16_t s1, uint16_t s2 )
+static int reliable_sequence_greater_than( uint16_t s1, uint16_t s2 )
 {
     return ( ( s1 > s2 ) && ( s1 - s2 <= 32768 ) ) || 
            ( ( s1 < s2 ) && ( s2 - s1  > 32768 ) );
 }
 
-int reliable_sequence_less_than( uint16_t s1, uint16_t s2 )
+static int reliable_sequence_less_than( uint16_t s1, uint16_t s2 )
 {
     return reliable_sequence_greater_than( s2, s1 );
 }
@@ -147,7 +168,9 @@ struct reliable_sequence_buffer_t
     uint8_t * entry_data;
 };
 
-struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_entries, 
+static void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer );
+
+static struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_entries, 
                                                                      int entry_stride, 
                                                                      void * allocator_context, 
                                                                      void * (*allocate_function)(void*,size_t), 
@@ -166,10 +189,28 @@ struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_ent
         free_function = reliable_default_free_function;
     }
 
+    size_t entry_sequence_bytes;
+    size_t entry_data_bytes;
+
+    if ( !reliable_checked_size( num_entries, sizeof( uint32_t ), &entry_sequence_bytes ) )
+    {
+        return NULL;
+    }
+
+    if ( !reliable_checked_size( num_entries, (size_t) entry_stride, &entry_data_bytes ) )
+    {
+        return NULL;
+    }
+
     struct reliable_sequence_buffer_t * sequence_buffer = (struct reliable_sequence_buffer_t*)
         allocate_function( allocator_context, sizeof( struct reliable_sequence_buffer_t ) );
 
-    reliable_assert( sequence_buffer );
+    if ( sequence_buffer == NULL )
+    {
+        return NULL;
+    }
+
+    memset( sequence_buffer, 0, sizeof( struct reliable_sequence_buffer_t ) );
 
     sequence_buffer->allocator_context = allocator_context;
     sequence_buffer->allocate_function = allocate_function;
@@ -177,32 +218,43 @@ struct reliable_sequence_buffer_t * reliable_sequence_buffer_create( int num_ent
     sequence_buffer->sequence = 0;
     sequence_buffer->num_entries = num_entries;
     sequence_buffer->entry_stride = entry_stride;
-    sequence_buffer->entry_sequence = (uint32_t*) allocate_function( allocator_context, num_entries * sizeof( uint32_t ) );
-    sequence_buffer->entry_data = (uint8_t*) allocate_function( allocator_context, num_entries * entry_stride );
-    reliable_assert( sequence_buffer->entry_sequence );
-    reliable_assert( sequence_buffer->entry_data );
-    memset( sequence_buffer->entry_sequence, 0xFF, sizeof( uint32_t) * sequence_buffer->num_entries );
-    memset( sequence_buffer->entry_data, 0, num_entries * entry_stride );
+    sequence_buffer->entry_sequence = (uint32_t*) allocate_function( allocator_context, entry_sequence_bytes );
+    sequence_buffer->entry_data = (uint8_t*) allocate_function( allocator_context, entry_data_bytes );
+
+    if ( sequence_buffer->entry_sequence == NULL || sequence_buffer->entry_data == NULL )
+    {
+        reliable_sequence_buffer_destroy( sequence_buffer );
+        return NULL;
+    }
+
+    memset( sequence_buffer->entry_sequence, 0xFF, entry_sequence_bytes );
+    memset( sequence_buffer->entry_data, 0, entry_data_bytes );
 
     return sequence_buffer;
 }
 
-void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer )
+static void reliable_sequence_buffer_destroy( struct reliable_sequence_buffer_t * sequence_buffer )
 {
     reliable_assert( sequence_buffer );
-    sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_sequence );
-    sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_data );
+    if ( sequence_buffer->entry_sequence )
+    {
+        sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_sequence );
+    }
+    if ( sequence_buffer->entry_data )
+    {
+        sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer->entry_data );
+    }
     sequence_buffer->free_function( sequence_buffer->allocator_context, sequence_buffer );
 }
 
-void reliable_sequence_buffer_reset( struct reliable_sequence_buffer_t * sequence_buffer )
+static void reliable_sequence_buffer_reset( struct reliable_sequence_buffer_t * sequence_buffer )
 {
     reliable_assert( sequence_buffer );
     sequence_buffer->sequence = 0;
     memset( sequence_buffer->entry_sequence, 0xFF, sizeof( uint32_t) * sequence_buffer->num_entries );
 }
 
-void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t * sequence_buffer, 
                                               int start_sequence, 
                                               int finish_sequence, 
                                               void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
@@ -242,12 +294,12 @@ void reliable_sequence_buffer_remove_entries( struct reliable_sequence_buffer_t 
     }
 }
 
-int reliable_sequence_buffer_test_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static int reliable_sequence_buffer_test_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     return reliable_sequence_less_than( sequence, sequence_buffer->sequence - ((uint16_t)sequence_buffer->num_entries) ) ? ((uint16_t)0) : ((uint16_t)1);
 }
 
-void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     if ( reliable_sequence_less_than( sequence, sequence_buffer->sequence - ((uint16_t)sequence_buffer->num_entries) ) )
@@ -264,7 +316,7 @@ void * reliable_sequence_buffer_insert( struct reliable_sequence_buffer_t * sequ
     return sequence_buffer->entry_data + index * sequence_buffer->entry_stride;
 }
 
-void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     if ( reliable_sequence_greater_than( sequence + 1, sequence_buffer->sequence ) )
@@ -274,7 +326,7 @@ void reliable_sequence_buffer_advance( struct reliable_sequence_buffer_t * seque
     }
 }
 
-void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
                                                      uint16_t sequence, 
                                                      void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -299,7 +351,7 @@ void * reliable_sequence_buffer_insert_with_cleanup( struct reliable_sequence_bu
     return sequence_buffer->entry_data + index * sequence_buffer->entry_stride;
 }
 
-void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer,
+static void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer,
                                                     uint16_t sequence,
                                                     void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -311,13 +363,7 @@ void reliable_sequence_buffer_advance_with_cleanup( struct reliable_sequence_buf
     }
 }
 
-void reliable_sequence_buffer_remove( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
-{
-    reliable_assert( sequence_buffer );
-    sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] = 0xFFFFFFFF;
-}
-
-void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
+static void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buffer_t * sequence_buffer, 
                                                    uint16_t sequence, 
                                                    void (*cleanup_function)(void*,void*,void(*free_function)(void*,void*)) )
 {
@@ -330,19 +376,13 @@ void reliable_sequence_buffer_remove_with_cleanup( struct reliable_sequence_buff
     }
 }
 
-int reliable_sequence_buffer_available( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
-{
-    reliable_assert( sequence_buffer );
-    return sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] == 0xFFFFFFFF;
-}
-
-int reliable_sequence_buffer_exists( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static int reliable_sequence_buffer_exists( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     return sequence_buffer->entry_sequence[ sequence % sequence_buffer->num_entries ] == (uint32_t) sequence;
 }
 
-void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
+static void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t sequence )
 {
     reliable_assert( sequence_buffer );
     int index = sequence % sequence_buffer->num_entries;
@@ -350,7 +390,7 @@ void * reliable_sequence_buffer_find( struct reliable_sequence_buffer_t * sequen
 
 }
 
-void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * sequence_buffer, int index )
+static void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * sequence_buffer, int index )
 {
     reliable_assert( sequence_buffer );
     reliable_assert( index >= 0 );
@@ -358,7 +398,7 @@ void * reliable_sequence_buffer_at_index( struct reliable_sequence_buffer_t * se
     return sequence_buffer->entry_sequence[index] != 0xFFFFFFFF ? ( sequence_buffer->entry_data + index * sequence_buffer->entry_stride ) : NULL;
 }
 
-void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t * ack, uint32_t * ack_bits )
+static void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer_t * sequence_buffer, uint16_t * ack, uint32_t * ack_bits )
 {
     reliable_assert( sequence_buffer );
     reliable_assert( ack );
@@ -378,50 +418,27 @@ void reliable_sequence_buffer_generate_ack_bits( struct reliable_sequence_buffer
 
 // ---------------------------------------------------------------
 
-void reliable_write_uint8( uint8_t ** p, uint8_t value )
+static void reliable_write_uint8( uint8_t ** p, uint8_t value )
 {
     **p = value;
     ++(*p);
 }
 
-void reliable_write_uint16( uint8_t ** p, uint16_t value )
+static void reliable_write_uint16( uint8_t ** p, uint16_t value )
 {
     (*p)[0] = value & 0xFF;
     (*p)[1] = value >> 8;
     *p += 2;
 }
 
-void reliable_write_uint32( uint8_t ** p, uint32_t value )
-{
-    (*p)[0] = value & 0xFF;
-    (*p)[1] = ( value >> 8  ) & 0xFF;
-    (*p)[2] = ( value >> 16 ) & 0xFF;
-    (*p)[3] = value >> 24;
-    *p += 4;
-}
-
-void reliable_write_uint64( uint8_t ** p, uint64_t value )
-{
-    (*p)[0] = value & 0xFF;
-    (*p)[1] = ( value >> 8  ) & 0xFF;
-    (*p)[2] = ( value >> 16 ) & 0xFF;
-    (*p)[3] = ( value >> 24 ) & 0xFF;
-    (*p)[4] = ( value >> 32 ) & 0xFF;
-    (*p)[5] = ( value >> 40 ) & 0xFF;
-    (*p)[6] = ( value >> 48 ) & 0xFF;
-    (*p)[7] = value >> 56;
-    *p += 8;
-}
-
-
-uint8_t reliable_read_uint8( uint8_t ** p )
+static uint8_t reliable_read_uint8( uint8_t ** p )
 {
     uint8_t value = **p;
     ++(*p);
     return value;
 }
 
-uint16_t reliable_read_uint16( uint8_t ** p )
+static uint16_t reliable_read_uint16( uint8_t ** p )
 {
     uint16_t value;
     value = (*p)[0];
@@ -429,33 +446,6 @@ uint16_t reliable_read_uint16( uint8_t ** p )
     *p += 2;
     return value;
 }
-
-uint32_t reliable_read_uint32( uint8_t ** p )
-{
-    uint32_t value;
-    value  = (*p)[0];
-    value |= ( ( (uint32_t)( (*p)[1] ) ) << 8 );
-    value |= ( ( (uint32_t)( (*p)[2] ) ) << 16 );
-    value |= ( ( (uint32_t)( (*p)[3] ) ) << 24 );
-    *p += 4;
-    return value;
-}
-
-uint64_t reliable_read_uint64( uint8_t ** p )
-{
-    uint64_t value;
-    value  = (*p)[0];
-    value |= ( ( (uint64_t)( (*p)[1] ) ) << 8  );
-    value |= ( ( (uint64_t)( (*p)[2] ) ) << 16 );
-    value |= ( ( (uint64_t)( (*p)[3] ) ) << 24 );
-    value |= ( ( (uint64_t)( (*p)[4] ) ) << 32 );
-    value |= ( ( (uint64_t)( (*p)[5] ) ) << 40 );
-    value |= ( ( (uint64_t)( (*p)[6] ) ) << 48 );
-    value |= ( ( (uint64_t)( (*p)[7] ) ) << 56 );
-    *p += 8;
-    return value;
-}
-
 
 // ---------------------------------------------------------------
 
@@ -472,7 +462,7 @@ struct reliable_fragment_reassembly_data_t
     uint8_t fragment_received[256];
 };
 
-void reliable_fragment_reassembly_data_cleanup( void * data, void * allocator_context, void (*free_function)(void*,void*) )
+static void reliable_fragment_reassembly_data_cleanup( void * data, void * allocator_context, void (*free_function)(void*,void*) )
 
 {
     reliable_assert( free_function );
@@ -556,20 +546,83 @@ void reliable_default_config( struct reliable_config_t * config )
     config->packet_header_size = 28;                    // note: UDP over IPv4 = 20 + 8 bytes, UDP over IPv6 = 40 + 8 bytes
 }
 
+// checks the config a caller hands to reliable_endpoint_create. every field is range checked
+// and the two relationships between fields are checked: a fragment threshold above the maximum
+// packet size can never fire, and a fragment count that does not cover the maximum packet size
+// means a large packet has nowhere to go. logs what is wrong and returns 0 to refuse the config
+
+static int reliable_config_valid( struct reliable_config_t * config )
+{
+    if ( config == NULL )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[reliable] config is NULL\n" );
+        return 0;
+    }
+
+    if ( config->max_packet_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_packet_size must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_above <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_above must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_size must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->max_fragments <= 0 || config->max_fragments > 256 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_fragments must be between 1 and 256\n", config->name );
+        return 0;
+    }
+
+    if ( config->ack_buffer_size <= 0 || config->sent_packets_buffer_size <= 0 || 
+         config->received_packets_buffer_size <= 0 || config->fragment_reassembly_buffer_size <= 0 || 
+         config->rtt_history_size <= 0 )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] buffer sizes must be positive\n", config->name );
+        return 0;
+    }
+
+    if ( config->transmit_packet_function == NULL || config->process_packet_function == NULL )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] transmit and process packet functions are required\n", config->name );
+        return 0;
+    }
+
+    if ( config->fragment_above > config->max_packet_size )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] fragment_above (%d) is above max_packet_size (%d)\n", 
+                         config->name, config->fragment_above, config->max_packet_size );
+        return 0;
+    }
+
+    // max_fragments * fragment_size must cover max_packet_size. written as a division of the
+    // two values already known to be positive, so neither side can overflow
+
+    if ( config->max_fragments <= ( config->max_packet_size - 1 ) / config->fragment_size )
+    {
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] max_fragments (%d) times fragment_size (%d) does not cover max_packet_size (%d)\n",
+                         config->name, config->max_fragments, config->fragment_size, config->max_packet_size );
+        return 0;
+    }
+
+    return 1;
+}
+
 struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time )
 {
-    reliable_assert( config );
-    reliable_assert( config->max_packet_size > 0 );
-    reliable_assert( config->fragment_above > 0 );
-    reliable_assert( config->max_fragments > 0 );
-    reliable_assert( config->max_fragments <= 256 );
-    reliable_assert( config->fragment_size > 0 );
-    reliable_assert( config->ack_buffer_size > 0 );
-    reliable_assert( config->sent_packets_buffer_size > 0 );
-    reliable_assert( config->received_packets_buffer_size > 0 );
-    reliable_assert( config->transmit_packet_function != NULL );
-    reliable_assert( config->process_packet_function != NULL );
-    reliable_assert( config->rtt_history_size > 0 );
+    if ( !reliable_config_valid( config ) )
+    {
+        return NULL;
+    }
 
     void * allocator_context = config->allocator_context;
     void * (*allocate_function)(void*,size_t) = config->allocate_function;
@@ -585,9 +638,46 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
         free_function = reliable_default_free_function;
     }
 
+    // every size the endpoint allocates, computed up front so an overflowing config is refused
+    // before anything is allocated
+
+    size_t acks_bytes;
+    size_t rtt_history_bytes;
+
+    if ( !reliable_checked_size( config->ack_buffer_size, sizeof( uint16_t ), &acks_bytes ) )
+    {
+        return NULL;
+    }
+
+    if ( !reliable_checked_size( config->rtt_history_size, sizeof( float ), &rtt_history_bytes ) )
+    {
+        return NULL;
+    }
+
+    // scratch buffer for outgoing packets, so the send path doesn't allocate. sized for whichever is larger: a regular packet or a fragment
+
+    if ( config->max_packet_size > INT_MAX - RELIABLE_MAX_PACKET_HEADER_BYTES || 
+         config->fragment_size > INT_MAX - RELIABLE_FRAGMENT_HEADER_BYTES - RELIABLE_MAX_PACKET_HEADER_BYTES )
+    {
+        return NULL;
+    }
+
+    int transmit_buffer_size = config->max_packet_size + RELIABLE_MAX_PACKET_HEADER_BYTES;
+    int fragment_transmit_buffer_size = RELIABLE_FRAGMENT_HEADER_BYTES + RELIABLE_MAX_PACKET_HEADER_BYTES + config->fragment_size;
+    if ( fragment_transmit_buffer_size > transmit_buffer_size )
+    {
+        transmit_buffer_size = fragment_transmit_buffer_size;
+    }
+
+    // from here on every allocation is checked and the failure path hands back everything
+    // already taken, in every build, so the caller only ever sees a complete endpoint or NULL
+
     struct reliable_endpoint_t * endpoint = (struct reliable_endpoint_t*) allocate_function( allocator_context, sizeof( struct reliable_endpoint_t ) );
 
-    reliable_assert( endpoint );
+    if ( endpoint == NULL )
+    {
+        return NULL;
+    }
 
     memset( endpoint, 0, sizeof( struct reliable_endpoint_t ) );
 
@@ -597,10 +687,7 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
     endpoint->config = *config;
     endpoint->time = time;
 
-    endpoint->acks = (uint16_t*) allocate_function( allocator_context, config->ack_buffer_size * sizeof(uint16_t) );
-
-    reliable_assert( endpoint->acks );
-
+    endpoint->acks = (uint16_t*) allocate_function( allocator_context, acks_bytes );
 
     endpoint->sent_packets = reliable_sequence_buffer_create( config->sent_packets_buffer_size, 
                                                               sizeof( struct reliable_sent_packet_data_t ), 
@@ -620,29 +707,28 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
                                                                      allocate_function, 
                                                                      free_function );
 
-    endpoint->rtt_history_buffer = (float*) allocate_function( allocator_context, config->rtt_history_size * sizeof(float) );
+    endpoint->rtt_history_buffer = (float*) allocate_function( allocator_context, rtt_history_bytes );
 
-    reliable_assert( endpoint->rtt_history_buffer );
+    endpoint->transmit_buffer = (uint8_t*) allocate_function( allocator_context, (size_t) transmit_buffer_size );
 
-    // scratch buffer for outgoing packets, so the send path doesn't allocate. sized for whichever is larger: a regular packet or a fragment
-
-    int transmit_buffer_size = config->max_packet_size + RELIABLE_MAX_PACKET_HEADER_BYTES;
-    int fragment_transmit_buffer_size = RELIABLE_FRAGMENT_HEADER_BYTES + RELIABLE_MAX_PACKET_HEADER_BYTES + config->fragment_size;
-    if ( fragment_transmit_buffer_size > transmit_buffer_size )
+    if ( endpoint->acks == NULL || 
+         endpoint->sent_packets == NULL || 
+         endpoint->received_packets == NULL || 
+         endpoint->fragment_reassembly == NULL || 
+         endpoint->rtt_history_buffer == NULL || 
+         endpoint->transmit_buffer == NULL )
     {
-        transmit_buffer_size = fragment_transmit_buffer_size;
+        reliable_printf( RELIABLE_LOG_LEVEL_ERROR, "[%s] failed to allocate endpoint\n", config->name );
+        reliable_endpoint_destroy( endpoint );
+        return NULL;
     }
-
-    endpoint->transmit_buffer = (uint8_t*) allocate_function( allocator_context, transmit_buffer_size );
-
-    reliable_assert( endpoint->transmit_buffer );
 
     for ( int i = 0; i < config->rtt_history_size; i++ )
     {
         endpoint->rtt_history_buffer[i] = -1.0f;
     }
 
-    memset( endpoint->acks, 0, config->ack_buffer_size * sizeof(uint16_t) );
+    memset( endpoint->acks, 0, acks_bytes );
 
     return endpoint;
 }
@@ -650,35 +736,55 @@ struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t 
 void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint )
 {
     reliable_assert( endpoint );
-    reliable_assert( endpoint->acks );
-    reliable_assert( endpoint->sent_packets );
-    reliable_assert( endpoint->received_packets );
-    reliable_assert( endpoint->fragment_reassembly );
-    reliable_assert( endpoint->rtt_history_buffer );
-    reliable_assert( endpoint->transmit_buffer );
 
-    int i;
-    for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
+    // every member is checked rather than asserted, because reliable_endpoint_create hands a
+    // partly built endpoint to this function to unwind an allocation failure
+
+    if ( endpoint->fragment_reassembly )
     {
-        struct reliable_fragment_reassembly_data_t * reassembly_data = (struct reliable_fragment_reassembly_data_t*) 
-            reliable_sequence_buffer_at_index( endpoint->fragment_reassembly, i );
-
-        if ( reassembly_data && reassembly_data->packet_data )
+        int i;
+        for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
         {
-            endpoint->free_function( endpoint->allocator_context, reassembly_data->packet_data );
-            reassembly_data->packet_data = NULL;
+            struct reliable_fragment_reassembly_data_t * reassembly_data = (struct reliable_fragment_reassembly_data_t*) 
+                reliable_sequence_buffer_at_index( endpoint->fragment_reassembly, i );
+
+            if ( reassembly_data && reassembly_data->packet_data )
+            {
+                endpoint->free_function( endpoint->allocator_context, reassembly_data->packet_data );
+                reassembly_data->packet_data = NULL;
+            }
         }
     }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->acks );
+    if ( endpoint->acks )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->acks );
+    }
 
-    reliable_sequence_buffer_destroy( endpoint->sent_packets );
-    reliable_sequence_buffer_destroy( endpoint->received_packets );
-    reliable_sequence_buffer_destroy( endpoint->fragment_reassembly );
+    if ( endpoint->sent_packets )
+    {
+        reliable_sequence_buffer_destroy( endpoint->sent_packets );
+    }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->rtt_history_buffer );
+    if ( endpoint->received_packets )
+    {
+        reliable_sequence_buffer_destroy( endpoint->received_packets );
+    }
 
-    endpoint->free_function( endpoint->allocator_context, endpoint->transmit_buffer );
+    if ( endpoint->fragment_reassembly )
+    {
+        reliable_sequence_buffer_destroy( endpoint->fragment_reassembly );
+    }
+
+    if ( endpoint->rtt_history_buffer )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->rtt_history_buffer );
+    }
+
+    if ( endpoint->transmit_buffer )
+    {
+        endpoint->free_function( endpoint->allocator_context, endpoint->transmit_buffer );
+    }
 
     endpoint->free_function( endpoint->allocator_context, endpoint );
 }
@@ -689,7 +795,7 @@ uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * en
     return endpoint->sequence;
 }
 
-int reliable_write_packet_header( uint8_t * packet_data, uint16_t sequence, uint16_t ack, uint32_t ack_bits )
+static int reliable_write_packet_header( uint8_t * packet_data, uint16_t sequence, uint16_t ack, uint32_t ack_bits )
 {
     uint8_t * p = packet_data;
 
@@ -864,7 +970,7 @@ void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8
     endpoint->counters[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_SENT]++;
 }
 
-int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_data, int packet_bytes, uint16_t * sequence, uint16_t * ack, uint32_t * ack_bits )
+static int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_data, int packet_bytes, uint16_t * sequence, uint16_t * ack, uint32_t * ack_bits )
 {
     if ( packet_bytes < 3 )
     {
@@ -948,7 +1054,7 @@ int reliable_read_packet_header( RELIABLE_CONST char * name, uint8_t * packet_da
     return (int) ( p - packet_data );
 }
 
-int reliable_read_fragment_header( char * name, 
+static int reliable_read_fragment_header( char * name, 
                                    uint8_t * packet_data, 
                                    int packet_bytes, 
                                    int max_fragments, 
@@ -1051,7 +1157,7 @@ int reliable_read_fragment_header( char * name,
     return (int) ( p - packet_data );
 }
 
-void reliable_store_fragment_data( struct reliable_fragment_reassembly_data_t * reassembly_data, 
+static void reliable_store_fragment_data( struct reliable_fragment_reassembly_data_t * reassembly_data, 
                                    uint16_t sequence, 
                                    uint16_t ack, 
                                    uint32_t ack_bits, 
@@ -1349,7 +1455,7 @@ void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void 
     endpoint->free_function( endpoint->allocator_context, packet );
 }
 
-uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks )
+RELIABLE_CONST uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks )
 {
     reliable_assert( endpoint );
     reliable_assert( num_acks );
@@ -1370,8 +1476,29 @@ void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint )
     endpoint->num_acks = 0;
     endpoint->sequence = 0;
 
+    // every value a getter can return goes back to what it was at create, so the header's
+    // promise holds for the statistics as well as for the buffers
+
+    endpoint->rtt = 0.0f;
+    endpoint->rtt_min = 0.0f;
+    endpoint->rtt_max = 0.0f;
+    endpoint->rtt_avg = 0.0f;
+    endpoint->jitter_avg_vs_min_rtt = 0.0f;
+    endpoint->jitter_max_vs_min_rtt = 0.0f;
+    endpoint->jitter_stddev_vs_avg_rtt = 0.0f;
+    endpoint->packet_loss = 0.0f;
+    endpoint->sent_bandwidth_kbps = 0.0f;
+    endpoint->received_bandwidth_kbps = 0.0f;
+    endpoint->acked_bandwidth_kbps = 0.0f;
+
     memset( endpoint->acks, 0, endpoint->config.ack_buffer_size * sizeof( uint16_t ) );
     memset( endpoint->counters, 0, RELIABLE_ENDPOINT_NUM_COUNTERS * sizeof( uint64_t ) );
+
+    int rtt_index;
+    for ( rtt_index = 0; rtt_index < endpoint->config.rtt_history_size; ++rtt_index )
+    {
+        endpoint->rtt_history_buffer[rtt_index] = -1.0f;
+    }
 
     int i;
     for ( i = 0; i < endpoint->config.fragment_reassembly_buffer_size; ++i )
@@ -1399,7 +1526,7 @@ void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double tim
 
     // calculate min and max rtt
     {
-        float min_rtt = 10000.0f;
+        float min_rtt = FLT_MAX;
         float max_rtt = 0.0f;
         float sum_rtt = 0.0f;
         int count = 0;
@@ -1420,18 +1547,19 @@ void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double tim
                 count++;
             }
         }
-        if ( min_rtt == 10000.0f )
-        {
-            min_rtt = 0.0f;
-        }
-        endpoint->rtt_min = min_rtt;
-        endpoint->rtt_max = max_rtt;
+        // the sample count, not the value of min_rtt, says whether the history is empty. a
+        // sentinel compared against a real rtt reports 0 for a link slow enough to reach it
+
         if ( count > 0 )
         {
+            endpoint->rtt_min = min_rtt;
+            endpoint->rtt_max = max_rtt;
             endpoint->rtt_avg = sum_rtt / (float)count;
         }
         else
         {
+            endpoint->rtt_min = 0.0f;
+            endpoint->rtt_max = 0.0f;
             endpoint->rtt_avg = 0.0f;
         }
     }
@@ -1754,6 +1882,7 @@ static void check_handler( RELIABLE_CONST char * condition,
                            int line )
 {
     printf( "check failed: ( %s ), function %s, file %s, line %d\n", condition, function, file, line );
+    fflush( stdout );
 #ifdef RELIABLE_DEBUG
     #if defined( __GNUC__ )
         __builtin_trap();
@@ -2093,7 +2222,7 @@ static void test_acks()
     uint8_t sender_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( sender_acked_packet, 0, sizeof( sender_acked_packet ) );
     int sender_num_acks;
-    uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
+    RELIABLE_CONST uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
     for ( i = 0; i < sender_num_acks; ++i )
     {
         if ( sender_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2109,7 +2238,7 @@ static void test_acks()
     uint8_t receiver_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( receiver_acked_packet, 0, sizeof( receiver_acked_packet ) );
     int receiver_num_acks;
-    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
+    RELIABLE_CONST uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
     for ( i = 0; i < receiver_num_acks; ++i )
     {
         if ( receiver_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2172,7 +2301,7 @@ static void test_acks_packet_loss()
     uint8_t sender_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( sender_acked_packet, 0, sizeof( sender_acked_packet ) );
     int sender_num_acks;
-    uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
+    RELIABLE_CONST uint16_t * sender_acks = reliable_endpoint_get_acks( context.sender, &sender_num_acks );
     for ( i = 0; i < sender_num_acks; ++i )
     {
         if ( sender_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -2188,7 +2317,7 @@ static void test_acks_packet_loss()
     uint8_t receiver_acked_packet[TEST_ACKS_NUM_ITERATIONS];
     memset( receiver_acked_packet, 0, sizeof( receiver_acked_packet ) );
     int receiver_num_acks;
-    uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
+    RELIABLE_CONST uint16_t * receiver_acks = reliable_endpoint_get_acks( context.receiver, &receiver_num_acks );
     for ( i = 0; i < receiver_num_acks; ++i )
     {
         if ( receiver_acks[i] < TEST_ACKS_NUM_ITERATIONS )
@@ -3031,6 +3160,760 @@ static void test_rtt()
     reliable_endpoint_destroy(context.receiver);
 }
 
+// a pair of endpoints wired to each other through test_transmit_packet_function
+
+struct test_pair_t
+{
+    struct test_context_t context;
+    struct reliable_config_t sender_config;
+    struct reliable_config_t receiver_config;
+};
+
+static void test_pair_configs( struct test_pair_t * pair )
+{
+    test_default_context( &pair->context );
+
+    reliable_default_config( &pair->sender_config );
+    reliable_default_config( &pair->receiver_config );
+
+    reliable_copy_string( pair->sender_config.name, "sender", sizeof( pair->sender_config.name ) );
+    pair->sender_config.context = &pair->context;
+    pair->sender_config.id = 0;
+    pair->sender_config.transmit_packet_function = &test_transmit_packet_function;
+    pair->sender_config.process_packet_function = &test_process_packet_function;
+
+    reliable_copy_string( pair->receiver_config.name, "receiver", sizeof( pair->receiver_config.name ) );
+    pair->receiver_config.context = &pair->context;
+    pair->receiver_config.id = 1;
+    pair->receiver_config.transmit_packet_function = &test_transmit_packet_function;
+    pair->receiver_config.process_packet_function = &test_process_packet_function;
+}
+
+static void test_pair_create( struct test_pair_t * pair, double time )
+{
+    pair->context.sender = reliable_endpoint_create( &pair->sender_config, time );
+    pair->context.receiver = reliable_endpoint_create( &pair->receiver_config, time );
+    check( pair->context.sender );
+    check( pair->context.receiver );
+}
+
+static void test_pair_destroy( struct test_pair_t * pair )
+{
+    reliable_endpoint_destroy( pair->context.sender );
+    reliable_endpoint_destroy( pair->context.receiver );
+}
+
+// RL-02: a round trip long enough to reach any fixed sentinel must still be reported
+
+static void test_rtt_min_large()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    uint8_t packet[8];
+    memset( packet, 0, sizeof( packet ) );
+
+    reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+
+    // ten seconds pass before the acknowledgment comes back, so the one rtt sample is 10,000 ms
+
+    time += 10.0;
+
+    reliable_endpoint_update( pair.context.sender, time );
+    reliable_endpoint_update( pair.context.receiver, time );
+
+    reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+    reliable_endpoint_update( pair.context.sender, time );
+
+    int num_acks;
+    reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( num_acks == 1 );
+
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 10000.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+
+    // and an endpoint with no samples at all still reports zero
+
+    check( reliable_endpoint_rtt_min( pair.context.receiver ) == 0.0f );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-03: reset clears every field a getter can return, the rtt history included
+
+static void test_endpoint_reset_clears_stats()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    // enough packets that the bandwidth window, which samples half the sent packets buffer,
+    // lands on packets that were actually sent
+
+    int i;
+    for ( i = 0; i < 300; ++i )
+    {
+        uint8_t packet[64];
+        memset( packet, 0, sizeof( packet ) );
+
+        // the reply comes back a step later, so the acknowledgment carries a real round trip
+
+        reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+
+        time += 0.1;
+        reliable_endpoint_update( pair.context.sender, time );
+        reliable_endpoint_update( pair.context.receiver, time );
+
+        reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+        time += 0.1;
+        reliable_endpoint_update( pair.context.sender, time );
+        reliable_endpoint_update( pair.context.receiver, time );
+
+        reliable_endpoint_clear_acks( pair.context.sender );
+        reliable_endpoint_clear_acks( pair.context.receiver );
+    }
+
+    check( reliable_endpoint_rtt( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_min( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) > 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) > 0.0f );
+
+    float sent_bandwidth, received_bandwidth, acked_bandwidth;
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+    check( sent_bandwidth > 0.0f );
+    check( received_bandwidth > 0.0f );
+    check( acked_bandwidth > 0.0f );
+
+    reliable_endpoint_reset( pair.context.sender );
+
+    check( reliable_endpoint_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_packet_loss( pair.context.sender ) == 0.0f );
+
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+    check( sent_bandwidth == 0.0f );
+    check( received_bandwidth == 0.0f );
+    check( acked_bandwidth == 0.0f );
+
+    // the rtt history is part of the state, so recomputing the statistics after a reset must
+    // not resurrect the samples that were in it
+
+    time += 0.1;
+    reliable_endpoint_update( pair.context.sender, time );
+
+    check( reliable_endpoint_rtt_min( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_max( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_rtt_avg( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender ) == 0.0f );
+    check( reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender ) == 0.0f );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-06: a config the library cannot honor is refused instead of asserted
+
+static void test_endpoint_create_invalid_config()
+{
+    struct reliable_config_t valid;
+
+    reliable_default_config( &valid );
+    valid.transmit_packet_function = &test_transmit_packet_function;
+    valid.process_packet_function = &test_process_packet_function;
+
+    struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &valid, 0.0 );
+    check( endpoint );
+    reliable_endpoint_destroy( endpoint );
+
+    check( reliable_endpoint_create( NULL, 0.0 ) == NULL );
+
+    struct reliable_config_t config;
+
+    // the two relationships between fields
+
+    config = valid;
+    config.fragment_above = config.max_packet_size + 1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid;
+    config.max_fragments = 4;
+    config.fragment_size = 1024;
+    config.max_packet_size = 4 * 1024 + 1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    // exactly covering is allowed, one fragment short is not
+
+    config = valid;
+    config.max_fragments = 4;
+    config.fragment_size = 1024;
+    config.max_packet_size = 4 * 1024;
+    config.fragment_above = 1024;
+    endpoint = reliable_endpoint_create( &config, 0.0 );
+    check( endpoint );
+    reliable_endpoint_destroy( endpoint );
+
+    // ranges
+
+    config = valid; config.max_packet_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_above = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.max_fragments = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.max_fragments = 257;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.ack_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.sent_packets_buffer_size = -1;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.received_packets_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.fragment_reassembly_buffer_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.rtt_history_size = 0;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.transmit_packet_function = NULL;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    config = valid; config.process_packet_function = NULL;
+    check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+    // the size arithmetic behind every one of those buffers
+
+    size_t bytes = 0;
+
+    check( reliable_checked_size( 1, 4, &bytes ) );
+    check( bytes == 4 );
+
+    check( reliable_checked_size( 256, sizeof( uint16_t ), &bytes ) );
+    check( bytes == 512 );
+
+    check( !reliable_checked_size( 0, 4, &bytes ) );
+    check( !reliable_checked_size( -1, 4, &bytes ) );
+    check( !reliable_checked_size( 4, 0, &bytes ) );
+
+    // a product that does not fit in a size_t is refused rather than wrapped
+
+    check( !reliable_checked_size( 4, SIZE_MAX / 2, &bytes ) );
+    check( !reliable_checked_size( INT_MAX, SIZE_MAX / 3, &bytes ) );
+}
+
+// RL-06: every allocation failure returns NULL, in every build, having freed what it took
+
+#define TEST_FAILING_ALLOCATOR_SLOTS 64
+
+struct test_failing_allocate_context_t
+{
+    int fail_on;
+    int num_allocations;
+    void * active_allocations[TEST_FAILING_ALLOCATOR_SLOTS];
+};
+
+static void * test_failing_allocate_function( void * context, size_t bytes )
+{
+    struct test_failing_allocate_context_t * failing_context = (struct test_failing_allocate_context_t*) context;
+
+    if ( failing_context->num_allocations++ == failing_context->fail_on )
+    {
+        return NULL;
+    }
+
+    void * allocation = malloc( bytes );
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        if ( failing_context->active_allocations[i] == NULL )
+        {
+            failing_context->active_allocations[i] = allocation;
+            return allocation;
+        }
+    }
+
+    check( 0 );
+    return allocation;
+}
+
+static void test_failing_free_function( void * context, void * pointer )
+{
+    struct test_failing_allocate_context_t * failing_context = (struct test_failing_allocate_context_t*) context;
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        if ( failing_context->active_allocations[i] == pointer )
+        {
+            failing_context->active_allocations[i] = NULL;
+            free( pointer );
+            return;
+        }
+    }
+
+    check( 0 );
+}
+
+static void test_endpoint_create_allocation_failure()
+{
+    struct test_failing_allocate_context_t allocator;
+
+    struct reliable_config_t config;
+    reliable_default_config( &config );
+    config.transmit_packet_function = &test_transmit_packet_function;
+    config.process_packet_function = &test_process_packet_function;
+    config.allocator_context = &allocator;
+    config.allocate_function = &test_failing_allocate_function;
+    config.free_function = &test_failing_free_function;
+
+    // how many allocations a successful create makes
+
+    memset( &allocator, 0, sizeof( allocator ) );
+    allocator.fail_on = -1;
+
+    struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &config, 0.0 );
+    check( endpoint );
+
+    const int num_allocations = allocator.num_allocations;
+    check( num_allocations > 1 );
+
+    reliable_endpoint_destroy( endpoint );
+
+    int i;
+    for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+    {
+        check( allocator.active_allocations[i] == NULL );
+    }
+
+    // fail each one in turn
+
+    int fail_on;
+    for ( fail_on = 0; fail_on < num_allocations; ++fail_on )
+    {
+        memset( &allocator, 0, sizeof( allocator ) );
+        allocator.fail_on = fail_on;
+
+        check( reliable_endpoint_create( &config, 0.0 ) == NULL );
+
+        for ( i = 0; i < TEST_FAILING_ALLOCATOR_SLOTS; ++i )
+        {
+            check( allocator.active_allocations[i] == NULL );
+        }
+    }
+}
+
+// RL-07: the sequence number crosses 65535 to 0
+
+static uint8_t test_wrap_acked[65536];
+
+static void test_sequence_wrap()
+{
+    double time = 100.0;
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, time );
+
+    memset( test_wrap_acked, 0, sizeof( test_wrap_acked ) );
+
+    const int num_iterations = 65536 + 64;
+
+    int i;
+    for ( i = 0; i < num_iterations; ++i )
+    {
+        uint8_t packet[8];
+        memset( packet, 0, sizeof( packet ) );
+
+        reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+        reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+        int num_acks;
+        RELIABLE_CONST uint16_t * acks = reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+
+        int j;
+        for ( j = 0; j < num_acks; ++j )
+        {
+            test_wrap_acked[acks[j]] = 1;
+        }
+
+        reliable_endpoint_clear_acks( pair.context.sender );
+        reliable_endpoint_clear_acks( pair.context.receiver );
+    }
+
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == (uint16_t) num_iterations );
+
+    // the sequences either side of the wrap were acked like any others
+
+    check( test_wrap_acked[65533] );
+    check( test_wrap_acked[65534] );
+    check( test_wrap_acked[65535] );
+    check( test_wrap_acked[0] );
+    check( test_wrap_acked[1] );
+    check( test_wrap_acked[2] );
+
+    for ( i = 0; i < 65536; ++i )
+    {
+        check( test_wrap_acked[i] );
+    }
+
+    check( reliable_endpoint_counters( pair.context.receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_RECEIVED] == (uint64_t) num_iterations );
+
+    test_pair_destroy( &pair );
+}
+
+// RL-07: fragment counts at both ends of the range, and a payload that is an exact multiple
+// of the fragment size
+
+struct test_fragment_context_t
+{
+    struct test_context_t base;
+    int num_processed;
+    int processed_bytes;
+    uint8_t processed[64 * 1024];
+};
+
+static int test_fragment_process_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+
+    struct test_fragment_context_t * context = (struct test_fragment_context_t*) _context;
+
+    check( packet_bytes <= (int) sizeof( context->processed ) );
+
+    context->num_processed++;
+    context->processed_bytes = packet_bytes;
+    memcpy( context->processed, packet_data, packet_bytes );
+
+    return 1;
+}
+
+static void test_fragment_case( int fragment_size, int max_fragments, int packet_bytes, int expected_fragments )
+{
+    struct test_fragment_context_t context;
+    memset( &context, 0, sizeof( context ) );
+    context.base.allow_packets = -1;
+
+    struct reliable_config_t sender_config;
+    struct reliable_config_t receiver_config;
+
+    reliable_default_config( &sender_config );
+    reliable_default_config( &receiver_config );
+
+    sender_config.fragment_size = fragment_size;
+    sender_config.max_fragments = max_fragments;
+    sender_config.max_packet_size = fragment_size * max_fragments;
+    sender_config.fragment_above = fragment_size;
+    receiver_config = sender_config;
+
+    reliable_copy_string( sender_config.name, "sender", sizeof( sender_config.name ) );
+    sender_config.context = &context;
+    sender_config.id = 0;
+    sender_config.transmit_packet_function = &test_transmit_packet_function;
+    sender_config.process_packet_function = &test_fragment_process_packet_function;
+
+    reliable_copy_string( receiver_config.name, "receiver", sizeof( receiver_config.name ) );
+    receiver_config.context = &context;
+    receiver_config.id = 1;
+    receiver_config.transmit_packet_function = &test_transmit_packet_function;
+    receiver_config.process_packet_function = &test_fragment_process_packet_function;
+
+    context.base.sender = reliable_endpoint_create( &sender_config, 100.0 );
+    context.base.receiver = reliable_endpoint_create( &receiver_config, 100.0 );
+    check( context.base.sender );
+    check( context.base.receiver );
+
+    uint8_t * packet = (uint8_t*) malloc( packet_bytes );
+    check( packet );
+
+    int i;
+    for ( i = 0; i < packet_bytes; ++i )
+    {
+        packet[i] = (uint8_t) ( ( i * 31 ) + 7 );
+    }
+
+    reliable_endpoint_send_packet( context.base.sender, packet, packet_bytes );
+
+    check( context.num_processed == 1 );
+    check( context.processed_bytes == packet_bytes );
+    check( memcmp( context.processed, packet, packet_bytes ) == 0 );
+
+    const uint64_t fragments_sent = reliable_endpoint_counters( context.base.sender )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_SENT];
+    const uint64_t fragments_received = reliable_endpoint_counters( context.base.receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED];
+
+    if ( expected_fragments == 0 )
+    {
+        // below the threshold: sent whole, no fragments at all
+        check( fragments_sent == 0 );
+        check( fragments_received == 0 );
+    }
+    else
+    {
+        check( fragments_sent == (uint64_t) expected_fragments );
+        check( fragments_received == (uint64_t) expected_fragments );
+    }
+
+    free( packet );
+
+    reliable_endpoint_destroy( context.base.sender );
+    reliable_endpoint_destroy( context.base.receiver );
+}
+
+static void test_fragment_counts()
+{
+    // an exact multiple of the fragment size, where the last fragment is full rather than a remainder
+    test_fragment_case( 512, 16, 512 * 4, 4 );
+
+    // the largest packet the config allows, again an exact multiple
+    test_fragment_case( 512, 16, 512 * 16, 16 );
+
+    // one fragment: above the threshold by a single byte
+    test_fragment_case( 512, 16, 513, 2 );
+    test_fragment_case( 64, 256, 65, 2 );
+
+    // 256 fragments, the maximum the wire format can express
+    test_fragment_case( 64, 256, 64 * 256, 256 );
+    test_fragment_case( 64, 256, 64 * 255 + 1, 256 );
+
+    // at or below the threshold the packet is not fragmented
+    test_fragment_case( 512, 16, 512, 0 );
+    test_fragment_case( 512, 16, 1, 0 );
+}
+
+// RL-07: truncated packets and fragments are rejected rather than acted on
+
+struct test_truncation_context_t
+{
+    struct test_context_t base;
+    int num_processed;
+    int num_captured;
+    int captured_bytes[300];
+    uint8_t captured[300][1024];
+};
+
+static void test_truncation_transmit_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+
+    struct test_truncation_context_t * context = (struct test_truncation_context_t*) _context;
+
+    if ( context->num_captured < (int) ARRAY_LENGTH( context->captured_bytes ) && packet_bytes <= (int) sizeof( context->captured[0] ) )
+    {
+        memcpy( context->captured[context->num_captured], packet_data, packet_bytes );
+        context->captured_bytes[context->num_captured] = packet_bytes;
+        context->num_captured++;
+    }
+}
+
+static int test_truncation_process_packet_function( void * _context, uint64_t id, uint16_t sequence, uint8_t * packet_data, int packet_bytes )
+{
+    (void) id;
+    (void) sequence;
+    (void) packet_data;
+    (void) packet_bytes;
+
+    struct test_truncation_context_t * context = (struct test_truncation_context_t*) _context;
+    context->num_processed++;
+    return 1;
+}
+
+static void test_truncated_packets()
+{
+    struct test_truncation_context_t context;
+    memset( &context, 0, sizeof( context ) );
+    context.base.allow_packets = -1;
+
+    struct reliable_config_t config;
+    reliable_default_config( &config );
+    config.fragment_size = 256;
+    config.max_fragments = 16;
+    config.max_packet_size = 256 * 16;
+    config.fragment_above = 256;
+    config.context = &context;
+    config.id = 0;
+    config.transmit_packet_function = &test_truncation_transmit_packet_function;
+    config.process_packet_function = &test_truncation_process_packet_function;
+
+    struct reliable_endpoint_t * sender = reliable_endpoint_create( &config, 100.0 );
+    struct reliable_endpoint_t * receiver = reliable_endpoint_create( &config, 100.0 );
+    check( sender );
+    check( receiver );
+
+    // an unfragmented packet, captured on the wire
+
+    uint8_t packet[200];
+    memset( packet, 0xAB, sizeof( packet ) );
+    reliable_endpoint_send_packet( sender, packet, sizeof( packet ) );
+    check( context.num_captured == 1 );
+
+    const int whole_bytes = context.captured_bytes[0];
+
+    // every truncation of it shorter than the header is rejected, and none is processed
+
+    int truncated_bytes;
+    for ( truncated_bytes = 1; truncated_bytes < 4; ++truncated_bytes )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[0], truncated_bytes );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_INVALID] == 3 );
+    check( context.num_processed == 0 );
+
+    // the whole packet still arrives
+
+    reliable_endpoint_receive_packet( receiver, context.captured[0], whole_bytes );
+    check( context.num_processed == 1 );
+
+    // now a fragmented packet
+
+    context.num_captured = 0;
+
+    uint8_t large_packet[1024];
+    memset( large_packet, 0xCD, sizeof( large_packet ) );
+    reliable_endpoint_send_packet( sender, large_packet, sizeof( large_packet ) );
+    check( context.num_captured == 4 );
+
+    // a fragment truncated inside its header is rejected
+
+    for ( truncated_bytes = 1; truncated_bytes < RELIABLE_FRAGMENT_HEADER_BYTES; ++truncated_bytes )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[1], truncated_bytes );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 0 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_INVALID] == RELIABLE_FRAGMENT_HEADER_BYTES - 1 );
+
+    // a fragment that is not the last one must carry exactly fragment_size bytes, so a
+    // truncated body is rejected too
+
+    reliable_endpoint_receive_packet( receiver, context.captured[1], context.captured_bytes[1] - 1 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 0 );
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_INVALID] == RELIABLE_FRAGMENT_HEADER_BYTES );
+    check( context.num_processed == 1 );
+
+    // the intact fragments reassemble
+
+    int i;
+    for ( i = 0; i < context.num_captured; ++i )
+    {
+        reliable_endpoint_receive_packet( receiver, context.captured[i], context.captured_bytes[i] );
+    }
+
+    check( reliable_endpoint_counters( receiver )[RELIABLE_ENDPOINT_COUNTER_NUM_FRAGMENTS_RECEIVED] == 4 );
+    check( context.num_processed == 2 );
+
+    reliable_endpoint_destroy( sender );
+    reliable_endpoint_destroy( receiver );
+}
+
+// every function reliable.h declares is called at least once by the suite. this test names
+// them all in one place so a new entry point cannot be added without being exercised
+
+static int test_surface_printf_calls = 0;
+
+static int test_surface_printf_function( RELIABLE_CONST char * format, ... )
+{
+    (void) format;
+    test_surface_printf_calls++;
+    return 0;
+}
+
+static void test_public_api_surface()
+{
+    check( reliable_init() == RELIABLE_OK );
+
+    reliable_set_assert_function( reliable_assert_function );
+
+    reliable_set_printf_function( &test_surface_printf_function );
+    reliable_log_level( RELIABLE_LOG_LEVEL_NONE );
+
+    struct test_pair_t pair;
+    test_pair_configs( &pair );
+    test_pair_create( &pair, 100.0 );
+
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == 0 );
+
+    uint8_t packet[64];
+    memset( packet, 0, sizeof( packet ) );
+
+    reliable_endpoint_send_packet( pair.context.sender, packet, sizeof( packet ) );
+    reliable_endpoint_send_packet( pair.context.receiver, packet, sizeof( packet ) );
+
+    reliable_endpoint_receive_packet( pair.context.sender, packet, sizeof( packet ) );
+
+    reliable_endpoint_update( pair.context.sender, 100.1 );
+
+    int num_acks = 0;
+    RELIABLE_CONST uint16_t * acks = reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( acks );
+    check( num_acks == 1 );
+    reliable_endpoint_clear_acks( pair.context.sender );
+    reliable_endpoint_get_acks( pair.context.sender, &num_acks );
+    check( num_acks == 0 );
+
+    ( void ) reliable_endpoint_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_min( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_max( pair.context.sender );
+    ( void ) reliable_endpoint_rtt_avg( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_avg_vs_min_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_max_vs_min_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_jitter_stddev_vs_avg_rtt( pair.context.sender );
+    ( void ) reliable_endpoint_packet_loss( pair.context.sender );
+
+    float sent_bandwidth, received_bandwidth, acked_bandwidth;
+    reliable_endpoint_bandwidth( pair.context.sender, &sent_bandwidth, &received_bandwidth, &acked_bandwidth );
+
+    check( reliable_endpoint_counters( pair.context.sender )[RELIABLE_ENDPOINT_COUNTER_NUM_PACKETS_SENT] == 1 );
+
+    reliable_endpoint_reset( pair.context.sender );
+    check( reliable_endpoint_next_packet_sequence( pair.context.sender ) == 0 );
+
+    void * owned = malloc( 32 );
+    check( owned );
+    reliable_endpoint_free_packet( pair.context.sender, owned );
+
+    char name[8];
+    reliable_copy_string( name, "abcdefghij", sizeof( name ) );
+    check( strcmp( name, "abcdefg" ) == 0 );
+
+    struct reliable_config_t defaults;
+    reliable_default_config( &defaults );
+    check( defaults.max_packet_size > 0 );
+
+    test_pair_destroy( &pair );
+
+    reliable_set_printf_function( ( int (*)( RELIABLE_CONST char *, ... ) ) printf );
+
+    reliable_term();
+    check( reliable_init() == RELIABLE_OK );
+}
+
 #define RUN_TEST( test_function )                                           \
     do                                                                      \
     {                                                                       \
@@ -3058,6 +3941,14 @@ void reliable_test()
         RUN_TEST( test_fragment_cleanup );
         RUN_TEST( test_rtt );
         RUN_TEST( test_endpoint_reset );
+        RUN_TEST( test_endpoint_reset_clears_stats );
+        RUN_TEST( test_rtt_min_large );
+        RUN_TEST( test_endpoint_create_invalid_config );
+        RUN_TEST( test_endpoint_create_allocation_failure );
+        RUN_TEST( test_sequence_wrap );
+        RUN_TEST( test_fragment_counts );
+        RUN_TEST( test_truncated_packets );
+        RUN_TEST( test_public_api_surface );
     }
 }
 

--- a/reliable.h
+++ b/reliable.h
@@ -32,10 +32,10 @@
 #ifndef RELIABLE_H
 #define RELIABLE_H
 
-#define RELIABLE_VERSION_FULL    "1.4.1"
+#define RELIABLE_VERSION_FULL    "1.4.2"
 #define RELIABLE_VERSION_MAJOR   1
 #define RELIABLE_VERSION_MINOR   4
-#define RELIABLE_VERSION_PATCH   1
+#define RELIABLE_VERSION_PATCH   2
 
 #include <stdint.h>
 #include <stddef.h>
@@ -95,6 +95,27 @@
 #define RELIABLE_OK         1
 #define RELIABLE_ERROR      0
 
+// the public surface. every function below carries RELIABLE_EXPORT and nothing else in the
+// library does, so a shared build exports exactly this header and a static build is unchanged.
+// the build system defines RELIABLE_SHARED for both the library and its consumers when
+// BUILD_SHARED_LIBS is on, and RELIABLE_BUILDING for the library itself.
+
+#if defined(RELIABLE_SHARED)
+    #if defined(_WIN32) || defined(__CYGWIN__)
+        #if defined(RELIABLE_BUILDING)
+            #define RELIABLE_EXPORT __declspec(dllexport)
+        #else
+            #define RELIABLE_EXPORT __declspec(dllimport)
+        #endif
+    #elif defined(__GNUC__)
+        #define RELIABLE_EXPORT __attribute__((visibility("default")))
+    #else
+        #define RELIABLE_EXPORT
+    #endif
+#else
+    #define RELIABLE_EXPORT
+#endif
+
 #ifdef __cplusplus
 #define RELIABLE_CONST const
 extern "C" {
@@ -108,11 +129,11 @@ extern "C" {
 
 // initialize the library. call this once before creating any endpoints. returns RELIABLE_OK on success
 
-int reliable_init(void);
+RELIABLE_EXPORT int reliable_init(void);
 
 // shut down the library. call this once after all endpoints are destroyed
 
-void reliable_term(void);
+RELIABLE_EXPORT void reliable_term(void);
 
 struct reliable_config_t
 {
@@ -139,85 +160,128 @@ struct reliable_config_t
     void (*free_function)(void*,void*);                                         // custom free. NULL = free
 };
 
+// pointer lifetimes across the callbacks and the config:
+//
+//   context, allocator_context      owned by you. the endpoint stores them and hands them
+//                                   back unchanged, so they must outlive the endpoint. the
+//                                   library never dereferences either one.
+//
+//   transmit_packet_function
+//     packet_data                   points into the endpoint's own transmit scratch buffer
+//                                   and is valid only for the duration of the call. the next
+//                                   send on that endpoint overwrites it, which is why the
+//                                   callback must not send on the same endpoint. copy the
+//                                   bytes if you need them after you return.
+//
+//   process_packet_function
+//     packet_data                   valid only for the duration of the call. for an
+//                                   unfragmented packet it points into the buffer you passed
+//                                   to reliable_endpoint_receive_packet, past the header. for
+//                                   a reassembled packet it points into an internal buffer
+//                                   that the endpoint may free as soon as you return. copy the
+//                                   bytes if you need them after you return. it is yours to
+//                                   read, not to free: reliable_endpoint_free_packet is for
+//                                   memory you allocated with the endpoint's allocator.
+//
+//   allocate_function, free_function
+//                                   called for every allocation the endpoint makes, including
+//                                   during reliable_endpoint_create. returning NULL from
+//                                   allocate_function is a supported outcome: create frees
+//                                   whatever it had allocated and returns NULL.
+
 // fills a config with sensible defaults for a client/server game exchanging packets at 60HZ
 
-void reliable_default_config( struct reliable_config_t * config );
+RELIABLE_EXPORT void reliable_default_config( struct reliable_config_t * config );
 
 // creates an endpoint. one endpoint per connection: a client has one, a server has one per client slot.
 // endpoints are not thread safe: use one endpoint per-thread or protect each endpoint with your own lock.
 // (the log level, printf and assert handlers are global to the process.)
+//
+// returns NULL in every build, debug and release, if the config is not valid or if any
+// allocation fails. a refused config is one whose fields are out of range or whose
+// relationships do not hold: fragment_above must not exceed max_packet_size, and
+// max_fragments * fragment_size must cover max_packet_size. on failure nothing is retained:
+// every allocation already made is handed back to free_function before create returns.
+// check the result.
 
-struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time );
+RELIABLE_EXPORT struct reliable_endpoint_t * reliable_endpoint_create( struct reliable_config_t * config, double time );
 
 // returns the sequence number the next sent packet will have. use it to map acked sequence numbers back to the contents of packets you sent
 
-uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT uint16_t reliable_endpoint_next_packet_sequence( struct reliable_endpoint_t * endpoint );
 
 // sends a packet. the packet is handed to the transmit packet callback, split into fragments first if larger than config.fragment_above
 
-void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
+RELIABLE_EXPORT void reliable_endpoint_send_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
 
 // call this for each packet received from your socket. valid packets are passed to the process packet callback. stale and duplicate packets are dropped
 
-void reliable_endpoint_receive_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
+RELIABLE_EXPORT void reliable_endpoint_receive_packet( struct reliable_endpoint_t * endpoint, uint8_t * packet_data, int packet_bytes );
 
 // frees a packet using the endpoint's allocator
 
-void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void * packet );
+RELIABLE_EXPORT void reliable_endpoint_free_packet( struct reliable_endpoint_t * endpoint, void * packet );
 
-// returns the array of sequence numbers of sent packets acked since the last clear
+// returns a read only view of the sequence numbers of sent packets acked since the last clear.
+// the array belongs to the endpoint. it stays valid until the next call to
+// reliable_endpoint_receive_packet, reliable_endpoint_clear_acks, reliable_endpoint_reset or
+// reliable_endpoint_destroy on that endpoint. copy what you need before calling any of those
 
-uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks );
+RELIABLE_EXPORT RELIABLE_CONST uint16_t * reliable_endpoint_get_acks( struct reliable_endpoint_t * endpoint, int * num_acks );
 
 // clears the ack array. call this once per-frame after processing acks. if you don't, the ack buffer fills up and new acks are dropped
 
-void reliable_endpoint_clear_acks( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_clear_acks( struct reliable_endpoint_t * endpoint );
 
-// resets the endpoint to its initial state: acks, counters, sequence number and all tracking buffers are cleared
+// resets the endpoint to its initial state: acks, counters, sequence number, all tracking
+// buffers, the rtt history and every rtt, jitter, packet loss and bandwidth statistic are
+// cleared. the config and the allocator are kept, so the endpoint is immediately usable again
 
-void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_reset( struct reliable_endpoint_t * endpoint );
 
 // updates rtt, jitter, packet loss and bandwidth stats. call once per-frame with the current time
 
-void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double time );
+RELIABLE_EXPORT void reliable_endpoint_update( struct reliable_endpoint_t * endpoint, double time );
 
 // rtt and jitter are in milliseconds, packet loss is a percentage, bandwidth is in kilobits per-second
 
-float reliable_endpoint_rtt( struct reliable_endpoint_t * endpoint );       // exponentially smoothed moving average
+RELIABLE_EXPORT float reliable_endpoint_rtt( struct reliable_endpoint_t * endpoint );       // exponentially smoothed moving average
 
-float reliable_endpoint_rtt_min( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_min( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_rtt_max( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_max( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_rtt_avg( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_rtt_avg( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_avg_vs_min_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_avg_vs_min_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_max_vs_min_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_max_vs_min_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_jitter_stddev_vs_avg_rtt( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_jitter_stddev_vs_avg_rtt( struct reliable_endpoint_t * endpoint );
 
-float reliable_endpoint_packet_loss( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT float reliable_endpoint_packet_loss( struct reliable_endpoint_t * endpoint );
 
-void reliable_endpoint_bandwidth( struct reliable_endpoint_t * endpoint, float * sent_bandwidth_kbps, float * received_bandwidth_kbps, float * acked_bandwidth_kpbs );
+RELIABLE_EXPORT void reliable_endpoint_bandwidth( struct reliable_endpoint_t * endpoint, float * sent_bandwidth_kbps, float * received_bandwidth_kbps, float * acked_bandwidth_kpbs );
 
-// returns the array of RELIABLE_ENDPOINT_NUM_COUNTERS counters. index with RELIABLE_ENDPOINT_COUNTER_*
+// returns a read only view of the RELIABLE_ENDPOINT_NUM_COUNTERS counters, indexed with
+// RELIABLE_ENDPOINT_COUNTER_*. the array belongs to the endpoint and stays valid until it is
+// reset or destroyed
 
-RELIABLE_CONST uint64_t * reliable_endpoint_counters( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT RELIABLE_CONST uint64_t * reliable_endpoint_counters( struct reliable_endpoint_t * endpoint );
 
 // destroys an endpoint, freeing everything it allocated
 
-void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint );
+RELIABLE_EXPORT void reliable_endpoint_destroy( struct reliable_endpoint_t * endpoint );
 
 // sets the log level (process-wide). RELIABLE_LOG_LEVEL_NONE by default
 
-void reliable_log_level( int level );
+RELIABLE_EXPORT void reliable_log_level( int level );
 
 // overrides where log output goes (process-wide). default is printf
 
-void reliable_set_printf_function( int (*function)( RELIABLE_CONST char *, ... ) );
+RELIABLE_EXPORT void reliable_set_printf_function( int (*function)( RELIABLE_CONST char *, ... ) );
 
-extern void (*reliable_assert_function)( RELIABLE_CONST char *, RELIABLE_CONST char *, RELIABLE_CONST char * file, int line );
+RELIABLE_EXPORT extern void (*reliable_assert_function)( RELIABLE_CONST char *, RELIABLE_CONST char *, RELIABLE_CONST char * file, int line );
 
 #ifdef RELIABLE_DEBUG
 #define reliable_assert( condition )                                                        \
@@ -233,12 +297,12 @@ do                                                                              
 #define reliable_assert( ignore ) ((void)0)
 #endif
 
-void reliable_set_assert_function( void (*function)( RELIABLE_CONST char * /*condition*/, 
+RELIABLE_EXPORT void reliable_set_assert_function( void (*function)( RELIABLE_CONST char * /*condition*/, 
                                    RELIABLE_CONST char * /*function*/, 
                                    RELIABLE_CONST char * /*file*/, 
                                    int /*line*/ ) );
 
-void reliable_copy_string( char * dest, RELIABLE_CONST char * source, size_t dest_size );
+RELIABLE_EXPORT void reliable_copy_string( char * dest, RELIABLE_CONST char * source, size_t dest_size );
 
 #ifdef __cplusplus
 }

--- a/tools/conformance/gen_vectors.c
+++ b/tools/conformance/gen_vectors.c
@@ -10,9 +10,11 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdint.h>
-#include "reliable.h"
 
-int reliable_write_packet_header( uint8_t *, uint16_t, uint16_t, uint32_t );
+/* the header writer is internal to the library, so this translation unit is the library:
+   reliable.c is included rather than linked, which is also how the embedded test suite
+   reaches the same functions */
+#include "reliable.c"
 
 static void hex( uint8_t * b, int n ) { for ( int i = 0; i < n; i++ ) printf( "%02x", b[i] ); }
 
@@ -145,7 +147,7 @@ int main( void )
     config.fragment_above = 500;
     config.fragment_size = 500;
     config.max_fragments = 16;
-    config.max_packet_size = 8 * 1024;
+    config.max_packet_size = 16 * 500;
     config.transmit_packet_function = on_transmit;
     config.process_packet_function = on_process;
     struct reliable_endpoint_t * endpoint = reliable_endpoint_create( &config, 0.0 );

--- a/tools/conformance/verify_standard.py
+++ b/tools/conformance/verify_standard.py
@@ -17,7 +17,7 @@ def build_and_run(cc):
     src = os.path.join(ROOT, "tools", "conformance", "gen_vectors.c")
     with tempfile.TemporaryDirectory() as tmp:
         exe = os.path.join(tmp, "gen")
-        r = subprocess.run([cc, "-I" + ROOT, "-o", exe, src, os.path.join(ROOT, "reliable.c"), "-lm"],
+        r = subprocess.run([cc, "-I" + ROOT, "-o", exe, src, "-lm"],
                            capture_output=True, text=True)
         if r.returncode != 0:
             print("build failed:\n" + r.stderr[:2000], file=sys.stderr); sys.exit(2)

--- a/tools/symbols/check_header.cmake
+++ b/tools/symbols/check_header.cmake
@@ -1,0 +1,61 @@
+# Checks the promises reliable.h makes that no compiler can check for us.
+#
+# The two array getters must hand back a const view, and the header must state the lifetime
+# of every pointer that reaches a callback. Both are contract, and both are the kind of thing
+# that quietly rots, so they are pinned here.
+#
+# cmake -DRELIABLE_HEADER=<path> -P check_header.cmake
+
+if(NOT RELIABLE_HEADER)
+    message(FATAL_ERROR "RELIABLE_HEADER is required")
+endif()
+
+file(READ "${RELIABLE_HEADER}" header)
+
+set(failures "")
+
+# const views
+
+if(NOT header MATCHES "RELIABLE_EXPORT RELIABLE_CONST uint16_t \\* reliable_endpoint_get_acks")
+    list(APPEND failures "reliable_endpoint_get_acks must return RELIABLE_CONST uint16_t *")
+endif()
+
+if(NOT header MATCHES "RELIABLE_EXPORT RELIABLE_CONST uint64_t \\* reliable_endpoint_counters")
+    list(APPEND failures "reliable_endpoint_counters must return RELIABLE_CONST uint64_t *")
+endif()
+
+# documented pointer lifetimes
+
+if(NOT header MATCHES "pointer lifetimes")
+    list(APPEND failures "the header must carry a pointer lifetimes section")
+else()
+    string(REGEX MATCH "pointer lifetimes.*\n\n" lifetimes "${header}")
+    foreach(subject context allocator_context transmit_packet_function process_packet_function
+                    allocate_function free_function packet_data)
+        if(NOT lifetimes MATCHES "${subject}")
+            list(APPEND failures "the pointer lifetimes section says nothing about ${subject}")
+        endif()
+    endforeach()
+endif()
+
+# the array getters say how long their view stays valid
+
+foreach(getter reliable_endpoint_get_acks reliable_endpoint_counters)
+    string(FIND "${header}" "${getter}" position)
+    if(position EQUAL -1)
+        list(APPEND failures "${getter} is not declared")
+    endif()
+endforeach()
+
+if(NOT header MATCHES "stays valid until the next call to[ \t\r\n/]*reliable_endpoint_receive_packet")
+    list(APPEND failures "reliable_endpoint_get_acks must say when its view stops being valid")
+endif()
+
+if(failures)
+    foreach(failure IN LISTS failures)
+        message(SEND_ERROR "${failure}")
+    endforeach()
+    message(FATAL_ERROR "reliable.h does not keep the contract")
+endif()
+
+message(STATUS "reliable.h declares const views and documents every callback pointer lifetime")

--- a/tools/symbols/check_header.cmake
+++ b/tools/symbols/check_header.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.15)
+
 # Checks the promises reliable.h makes that no compiler can check for us.
 #
 # The two array getters must hand back a const view, and the header must state the lifetime

--- a/tools/symbols/check_symbols.cmake
+++ b/tools/symbols/check_symbols.cmake
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.15)
+
 # Checks that the library exports exactly the surface reliable.h declares.
 #
 # The set of names reliable.h marks RELIABLE_EXPORT is the contract. Every global symbol the

--- a/tools/symbols/check_symbols.cmake
+++ b/tools/symbols/check_symbols.cmake
@@ -1,0 +1,78 @@
+# Checks that the library exports exactly the surface reliable.h declares.
+#
+# The set of names reliable.h marks RELIABLE_EXPORT is the contract. Every global symbol the
+# compiled library defines must be one of them: anything else is an internal helper that
+# escaped, which is how a caller ends up depending on a function that is free to change.
+#
+# cmake -DRELIABLE_LIBRARY=<path> -DRELIABLE_HEADER=<path> -DRELIABLE_NM=<nm> -P check_symbols.cmake
+
+if(NOT RELIABLE_LIBRARY OR NOT RELIABLE_HEADER OR NOT RELIABLE_NM)
+    message(FATAL_ERROR "RELIABLE_LIBRARY, RELIABLE_HEADER and RELIABLE_NM are all required")
+endif()
+
+# the declared surface
+
+file(READ "${RELIABLE_HEADER}" header)
+string(REGEX MATCHALL "RELIABLE_EXPORT[^;]*;" declarations "${header}")
+
+set(declared "")
+foreach(declaration IN LISTS declarations)
+    if(declaration MATCHES "(reliable_[A-Za-z0-9_]+)[ \t\r\n]*\\(")
+        list(APPEND declared "${CMAKE_MATCH_1}")
+    elseif(declaration MATCHES "\\(\\*(reliable_[A-Za-z0-9_]+)\\)")
+        list(APPEND declared "${CMAKE_MATCH_1}")
+    endif()
+endforeach()
+list(REMOVE_DUPLICATES declared)
+list(SORT declared)
+list(LENGTH declared num_declared)
+
+# the defined surface
+
+execute_process(COMMAND "${RELIABLE_NM}" -g "${RELIABLE_LIBRARY}"
+                OUTPUT_VARIABLE nm_output RESULT_VARIABLE nm_result ERROR_VARIABLE nm_error)
+if(NOT nm_result EQUAL 0)
+    message(FATAL_ERROR "nm failed on ${RELIABLE_LIBRARY}: ${nm_error}")
+endif()
+
+string(REPLACE "\n" ";" nm_lines "${nm_output}")
+set(defined "")
+foreach(line IN LISTS nm_lines)
+    # "<address> <type> <name>", or "<type> <name>" for an undefined symbol
+    if(line MATCHES "^[0-9a-fA-F]* *([A-Za-z]) _?(reliable_[A-Za-z0-9_]+)$")
+        if(NOT CMAKE_MATCH_1 STREQUAL "U")
+            list(APPEND defined "${CMAKE_MATCH_2}")
+        endif()
+    endif()
+endforeach()
+list(REMOVE_DUPLICATES defined)
+list(SORT defined)
+list(LENGTH defined num_defined)
+
+# every global the library defines has to be one the header declares
+
+set(unexpected "")
+foreach(symbol IN LISTS defined)
+    if(NOT symbol IN_LIST declared)
+        list(APPEND unexpected "${symbol}")
+    endif()
+endforeach()
+
+set(missing "")
+foreach(symbol IN LISTS declared)
+    if(NOT symbol IN_LIST defined)
+        list(APPEND missing "${symbol}")
+    endif()
+endforeach()
+
+message(STATUS "reliable.h declares ${num_declared} exported names, the library defines ${num_defined}")
+
+if(unexpected)
+    message(FATAL_ERROR "the library exports symbols reliable.h does not declare: ${unexpected}")
+endif()
+
+if(missing)
+    message(FATAL_ERROR "reliable.h declares symbols the library does not define: ${missing}")
+endif()
+
+message(STATUS "the exported surface matches reliable.h exactly")


### PR DESCRIPTION
## R2 - the RTT sentinel

`reliable_endpoint_update` seeded `min_rtt` with `10000.0f` and mapped that value back to `0.0f`, so a link at or above 10,000 ms reported a minimum RTT of zero, which then distorted both jitter figures. `min_rtt` now starts at `FLT_MAX` and the sample count, not the value, decides whether the history is empty. `reliable.c`, the min/max RTT block in `reliable_endpoint_update`.

Test `test_rtt_min_large`: one exchange with ten seconds between send and acknowledgment, then `rtt_min`, `rtt_max` and `rtt_avg` must all be exactly 10000.0f and both jitter figures zero. An endpoint with no samples still reports zero.

## R3 - reset clears every observable field

`reliable_endpoint_reset` left the RTT history buffer and all eleven statistics fields untouched, so `reliable_endpoint_rtt_min` and friends kept reporting the old connection after a reset and the next `update` recomputed from stale samples. Reset now zeroes rtt, rtt_min, rtt_max, rtt_avg, the three jitter fields, packet loss and the three bandwidth fields, and refills the RTT history with the -1.0f empty marker. `reliable.h` describes what reset covers.

Test `test_endpoint_reset_clears_stats`: builds real statistics, asserts they are non zero, resets, asserts every getter returns zero, then updates again and asserts they are still zero.

## R4 - a C only build

`project(... LANGUAGES C)`, `target_compile_features(reliable PUBLIC c_std_99)`, and `enable_language(CXX)` only inside the `RELIABLE_BUILD_TESTS` branch, where `test.cpp` lives. The build type default is now guarded by `RELIABLE_TOP_LEVEL`, so a consumer pulling the library in through `add_subdirectory` or FetchContent keeps its own.

Test `configure_without_cxx`: configures the project with `-DRELIABLE_BUILD_TESTS=OFF` and a C++ compiler that does not exist. It has to succeed.

## R5 - a bounded export surface

Every internal helper is `static`. The 27 public functions and the `reliable_assert_function` pointer carry a new `RELIABLE_EXPORT` macro; `C_VISIBILITY_PRESET hidden` is on and `WINDOWS_EXPORT_ALL_SYMBOLS` is gone. Five wire helpers nothing called (`reliable_read_uint32`/`64`, `reliable_write_uint32`/`64`, `reliable_sequence_buffer_available`) and one unused sequence buffer function are removed.

A default object used to export 61 global `reliable_*` symbols. Test `symbols` (`tools/symbols/check_symbols.cmake`) reads the library's symbol table with `nm` and the `RELIABLE_EXPORT` declarations from `reliable.h`, and fails on any global that is not declared or any declaration that is not defined: 28 and 28, static and shared alike.

## R6 - creation is fallible in every build

`reliable_endpoint_create` guarded six allocation results with `reliable_assert`, which `RELIABLE_RELEASE` compiles to `((void)0)`, so a release build dereferenced NULL and never returned it. The README's `if ( endpoint == NULL )` was unreachable advice.

Creation now validates the config in every build, including both relationships between fields (`fragment_above` against `max_packet_size`, and `max_fragments * fragment_size` covering `max_packet_size`, written as a division so neither side can overflow), computes every allocation size through a checked helper, checks every allocation result, hands back everything it already took and returns NULL. `reliable_sequence_buffer_create` does the same. `reliable_endpoint_destroy` checks each member rather than asserting it, so it can unwind a partly built endpoint. The README's NULL check is now true, and `reliable.h` says so.

Tests: `test_endpoint_create_invalid_config` (both relationships, the exact-coverage boundary, every field range, missing callbacks, and the size arithmetic including a product that would not fit in a `size_t`) and `test_endpoint_create_allocation_failure`, which fails each allocation in turn and requires NULL back with the tracking allocator's slot table completely empty. Both run in Release, where the asserts are gone.

## R7 - the coverage gaps

- `test_sequence_wrap` sends 65,600 packets each way, so the sequence number crosses 65535 to 0, and requires that all 65,536 sequences were acknowledged. The old rollover test stopped at 32,768.
- `test_fragment_counts` covers exact multiples of the fragment size (4 and 16 fragments), the 1 fragment case, the 256 fragment case at both a full last fragment and a one byte last fragment, and the unfragmented cases at and below the threshold. Every case checks the payload came back byte for byte.
- `test_truncated_packets` truncates a regular packet inside its header, a fragment inside its header, and a non final fragment's body, and requires each to be rejected and never processed, with the intact packets still arriving.
- `test_public_api_surface` calls all 27 public functions.

## R8 - callback lifetimes and a const view

`reliable.h` now has a pointer lifetimes block: what `context` and `allocator_context` mean for ownership, that the `packet_data` a transmit callback receives is the endpoint's own scratch buffer and dies at return, that the `packet_data` a process callback receives is either the caller's buffer or an internal reassembly buffer and dies at return, and that a NULL from `allocate_function` is a supported outcome. `reliable_endpoint_get_acks` returns `RELIABLE_CONST uint16_t *`, and both array getters document how long the view stays valid.

Test `header_contract` (`tools/symbols/check_header.cmake`) fails if either getter loses its const return or if the lifetimes section stops covering any of the pointers.

## Version

1.4.2 in `reliable.h` and `CMakeLists.txt`.

## Check

Debug and Release, built one at a time, 7 of 7 CTest tests pass in each. `python3 tools/conformance/verify_standard.py`: 2608 checks, 0 failures. A shared build (`-DBUILD_SHARED_LIBS=ON`) passes the symbol test with the same 28. No sanitizer runs.

Negative controls, each reverting one rule and each demonstrated red:

| rule | control | red |
|---|---|---|
| R2 | `min_rtt` back to the `10000.0f` sentinel | `check failed: ( reliable_endpoint_rtt_min( pair.context.sender ) == 10000.0f )` in `test_rtt_min_large` |
| R3 | reset stops clearing the RTT history | `check failed: ( reliable_endpoint_rtt_min( pair.context.sender ) == 0.0f )` in `test_endpoint_reset_clears_stats` |
| R4 | `LANGUAGES C CXX` | `configure_without_cxx` fails, "Configuring incomplete, errors occurred!" |
| R5 | `reliable_write_packet_header` loses `static` | `symbols` fails: "declares 28 exported names, the library defines 29 ... exports symbols reliable.h does not declare" |
| R6 | the fragment coverage relationship check removed | `check failed: ( reliable_endpoint_create( &config, 0.0 ) == NULL )` in `test_endpoint_create_invalid_config` |
| R6 | the failure path returns without unwinding | `check failed: ( allocator.active_allocations[i] == NULL )` in `test_endpoint_create_allocation_failure` |
| R7 | `reliable_sequence_greater_than` compares without wrapping | `assert failed: ( sent_packet_data )` inside `test_sequence_wrap` |
| R7 | non final fragments no longer have to be full | `check failed: ( ..._NUM_FRAGMENTS_RECEIVED] == 0 )` in `test_truncated_packets` |
| R7 | the fragment count drops its remainder term | `check failed: ( fragments_sent == (uint64_t) expected_fragments )` in `test_fragment_case` |
| R8 | `get_acks` loses `RELIABLE_CONST` | `header_contract` fails: "reliable_endpoint_get_acks must return RELIABLE_CONST uint16_t *" |
| R8 | the lifetimes section removed | `header_contract` fails: "the header must carry a pointer lifetimes section" |

`CLAUDE.md` records the present contract: release still trusts the caller on the hot paths, and endpoint creation is the exception that validates in every build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
